### PR TITLE
Added `-v` flag to check current version in use

### DIFF
--- a/.changes/unreleased/Patch-20250918-121455.yaml
+++ b/.changes/unreleased/Patch-20250918-121455.yaml
@@ -1,0 +1,3 @@
+kind: Patch
+body: 'MCP server version is now returned when "-v" flag is passed. "neo4j-mcp -v"'
+time: 2025-09-18T12:14:55.289867+01:00

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ To build the project:
 go build -C cmd/neo4j-mcp -o ../../bin/
 ```
 
+Check the version:
+
+```bash
+go run ./cmd/neo4j-mcp -v
+```
+
 To run directly:
 
 ```bash

--- a/cmd/neo4j-mcp/main.go
+++ b/cmd/neo4j-mcp/main.go
@@ -2,13 +2,21 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"os"
 
 	"github.com/neo4j/mcp/internal/config"
 	"github.com/neo4j/mcp/internal/server"
 )
 
 func main() {
+	// Handle version flag
+	if len(os.Args) > 1 && os.Args[1] == "-v" {
+		// NOTE: "standard" log package logger write on on STDERR, in this case we want explicitly to write to STDOUT
+		fmt.Printf("neo4j-mcp version: %s\n", server.Version)
+		return
+	}
 	// get config from environment variables
 	cfg, err := config.LoadConfig()
 	if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,11 +12,15 @@ import (
 	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
 )
 
+// Version represents the current version of the neo4j-mcp server
+const Version = "0.1.1"
+
 // Neo4jMCPServer represents the MCP server instance
 type Neo4jMCPServer struct {
 	mcpServer *server.MCPServer
 	config    *config.Config
 	driver    *neo4j.DriverWithContext
+	version   string
 }
 
 // NewNeo4jMCPServer creates a new MCP server instance
@@ -24,7 +28,7 @@ type Neo4jMCPServer struct {
 func NewNeo4jMCPServer(cfg *config.Config) (*Neo4jMCPServer, error) {
 	mcpServer := server.NewMCPServer(
 		"neo4j-mcp",
-		"0.1.0",
+		Version,
 		server.WithToolCapabilities(true),
 	)
 
@@ -40,6 +44,7 @@ func NewNeo4jMCPServer(cfg *config.Config) (*Neo4jMCPServer, error) {
 		mcpServer: mcpServer,
 		config:    cfg,
 		driver:    &driver,
+		version:   Version,
 	}, nil
 }
 


### PR DESCRIPTION
Running `neo4j-mcp -v` now returns `neo4j-mcp version: {{current version}}` 