### PR TITLE
 Enhanced MCP tool annotations with title, destructive, idempotent, and open-world hints

### DIFF
--- a/.changes/unreleased/Patch-20250923-114240.yaml
+++ b/.changes/unreleased/Patch-20250923-114240.yaml
@@ -1,0 +1,3 @@
+kind: Patch
+body: Enhanced MCP tool annotations by adding title, destructive, idempotent, and open-world hints for get-schema and run-cypher tools to improve client understanding and behavior
+time: 2025-09-23T11:42:40.344874+01:00

--- a/internal/tools/get_schema_spec.go
+++ b/internal/tools/get_schema_spec.go
@@ -10,7 +10,10 @@ func GetSchemaSpec() mcp.Tool {
 		mcp.WithDescription(`
 		Retrieve the schema information from the Neo4j database, including node labels, relationship types, and property keys.
 		If the database contains no data, no schema information is returned.`),
+		mcp.WithTitleAnnotation("Get Neo4j Schema"),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
 	)
 }

--- a/internal/tools/run_cypher_spec.go
+++ b/internal/tools/run_cypher_spec.go
@@ -13,7 +13,10 @@ func RunCypherSpec() mcp.Tool {
 	return mcp.NewTool("run-cypher",
 		mcp.WithDescription("run-cypher executes any arbitrary Cypher query against the user-configured Neo4j database."),
 		mcp.WithInputSchema[RunCypherInput](),
+		mcp.WithTitleAnnotation("Run Cypher"),
 		mcp.WithReadOnlyHintAnnotation(false),
 		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
 	)
 }


### PR DESCRIPTION
Added comprehensive tool annotations to improve client understanding and behavior:

Added title annotations for better tool identification
Set destructive/idempotent/open-world hints for proper client handling
get-schema: non-destructive, idempotent, open-world
run-cypher: destructive, non-idempotent, open-world