### PR TITLE
Introduce read-cypher (read-only) tool and rename run-cypher to write-cypher

### DIFF
--- a/.changes/unreleased/Minor-20250930-163503.yaml
+++ b/.changes/unreleased/Minor-20250930-163503.yaml
@@ -1,0 +1,8 @@
+kind: Minor
+body: |
+  Renamed "run-cypher" to "write-cypher" and added "read-cypher".
+  The new read-cypher enforces read-only Cypher queries and only accepts queries
+  that do not modify data. It explicitly disallows admin/schema commands,
+  write queries, and profiling queries using the PROFILE keyword.
+
+time: 2025-09-30T16:35:03.012848+01:00

--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ Notes:
 
 Provided tools:
 
-| Tool         | Purpose                                              | Notes                                                                                      |
-| ------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `get-schema` | Introspect labels, relationship types, property keys | Read-only. Provide valuable context to the client LLMs.                                    |
-| `read-cypher` | Execute arbitrary Cypher (read mode)                | None.                                                                                      |
-| `write-cypher` | Execute arbitrary Cypher (write mode)              | **Caution:** LLM-generated queries could cause harm. Use only in development environments. |
+| Tool           | Purpose                                              | Notes                                                                                                |
+| -------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `get-schema`   | Introspect labels, relationship types, property keys | Read-only. Provide valuable context to the client LLMs.                                              |
+| `read-cypher`  | Execute arbitrary Cypher (read mode)                 | Read-only; rejects writes, schema/admin operations, and PROFILE queries. Use `write-cypher` instead  |
+| `write-cypher` | Execute arbitrary Cypher (write mode)                | **Caution:** LLM-generated queries could cause harm. Use only in development environments.           |
 
 ## Example Natural Language Prompts
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Provided tools:
 | Tool         | Purpose                                              | Notes                                                                                      |
 | ------------ | ---------------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | `get-schema` | Introspect labels, relationship types, property keys | Read-only. Provide valuable context to the client LLMs.                                    |
-| `run-cypher` | Execute arbitrary Cypher (read/write)                | **Caution:** LLM-generated queries could cause harm. Use only in development environments. |
+| `read-cypher` | Execute arbitrary Cypher (read mode)                | None.                                                                                      |
+| `write-cypher` | Execute arbitrary Cypher (write mode)              | **Caution:** LLM-generated queries could cause harm. Use only in development environments. |
 
 ## Example Natural Language Prompts
 

--- a/internal/database/interfaces.go
+++ b/internal/database/interfaces.go
@@ -15,6 +15,10 @@ type QueryExecutor interface {
 
 	// ExecuteWriteQuery executes a write-only Cypher query and returns raw records
 	ExecuteWriteQuery(ctx context.Context, cypher string, params map[string]any, database string) ([]*neo4j.Record, error)
+
+	// GetQueryType prefixes the provided query with EXPLAIN and returns the query type (e.g. 'r' for read, 'w' for write, 'rw' etc.)
+	// This allows read-only tools to determine if a query is safe to run in read-only context.
+	GetQueryType(ctx context.Context, cypher string, params map[string]any, database string) (string, error)
 }
 
 // RecordFormatter defines the interface for formatting Neo4j records

--- a/internal/database/mocks/mock_database.go
+++ b/internal/database/mocks/mock_database.go
@@ -71,6 +71,21 @@ func (mr *MockQueryExecutorMockRecorder) ExecuteWriteQuery(ctx, cypher, params, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteWriteQuery", reflect.TypeOf((*MockQueryExecutor)(nil).ExecuteWriteQuery), ctx, cypher, params, database)
 }
 
+// GetQueryType mocks base method.
+func (m *MockQueryExecutor) GetQueryType(ctx context.Context, cypher string, params map[string]any, database string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetQueryType", ctx, cypher, params, database)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetQueryType indicates an expected call of GetQueryType.
+func (mr *MockQueryExecutorMockRecorder) GetQueryType(ctx, cypher, params, database any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQueryType", reflect.TypeOf((*MockQueryExecutor)(nil).GetQueryType), ctx, cypher, params, database)
+}
+
 // MockRecordFormatter is a mock of RecordFormatter interface.
 type MockRecordFormatter struct {
 	ctrl     *gomock.Controller
@@ -162,6 +177,21 @@ func (m *MockDatabaseService) ExecuteWriteQuery(ctx context.Context, cypher stri
 func (mr *MockDatabaseServiceMockRecorder) ExecuteWriteQuery(ctx, cypher, params, database any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteWriteQuery", reflect.TypeOf((*MockDatabaseService)(nil).ExecuteWriteQuery), ctx, cypher, params, database)
+}
+
+// GetQueryType mocks base method.
+func (m *MockDatabaseService) GetQueryType(ctx context.Context, cypher string, params map[string]any, database string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetQueryType", ctx, cypher, params, database)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetQueryType indicates an expected call of GetQueryType.
+func (mr *MockDatabaseServiceMockRecorder) GetQueryType(ctx, cypher, params, database any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQueryType", reflect.TypeOf((*MockDatabaseService)(nil).GetQueryType), ctx, cypher, params, database)
 }
 
 // Neo4jRecordsToJSON mocks base method.

--- a/internal/database/service.go
+++ b/internal/database/service.go
@@ -76,6 +76,5 @@ func (s *Neo4jService) Neo4jRecordsToJSON(records []*neo4j.Record) (string, erro
 
 	formattedResponseStr := string(formattedResponse)
 
-
 	return formattedResponseStr, nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,7 +31,7 @@ func NewNeo4jMCPServer(cfg *config.Config) (*Neo4jMCPServer, error) {
 		Version,
 		server.WithToolCapabilities(true),
 		server.WithInstructions("This is the Neo4j official MCP server and can provide tool calling to interact with your Neo4j database,"+
-			"by inferring the schema with tools like get-schema and executing arbitrary Cypher queries with write-cypher."),
+			"by inferring the schema with tools like get-schema and executing arbitrary Cypher queries with read-cypher."),
 	)
 
 	// Initialize Neo4j driver once

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,7 +31,7 @@ func NewNeo4jMCPServer(cfg *config.Config) (*Neo4jMCPServer, error) {
 		Version,
 		server.WithToolCapabilities(true),
 		server.WithInstructions("This is the Neo4j official MCP server and can provide tool calling to interact with your Neo4j database,"+
-			"by inferring the schema with tools like get-schema and executing arbitrary Cypher queries with run-cypher."),
+			"by inferring the schema with tools like get-schema and executing arbitrary Cypher queries with write-cypher."),
 	)
 
 	// Initialize Neo4j driver once

--- a/internal/tools/read_cypher_handler.go
+++ b/internal/tools/read_cypher_handler.go
@@ -1,0 +1,61 @@
+package tools
+
+import (
+	"context"
+	"log"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/neo4j/mcp/internal/config"
+	"github.com/neo4j/mcp/internal/database"
+)
+
+func ReadCypherHandler(deps *ToolDependencies) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleReadCypher(ctx, request, deps.DBService, deps.Config)
+	}
+}
+
+func handleReadCypher(ctx context.Context, request mcp.CallToolRequest, dbService database.DatabaseService, config *config.Config) (*mcp.CallToolResult, error) {
+	var args ReadCypherInput
+	// Bind arguments to the struct
+	if err := request.BindArguments(&args); err != nil {
+		log.Printf("Error binding arguments: %v", err)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	Query := args.Query
+	Params := args.Params
+
+	log.Printf("cypher-query: %s", Query)
+
+	// Validate that query is not empty
+	if Query == "" {
+		errMessage := "Query parameter is required and cannot be empty"
+		log.Printf("%s", errMessage)
+		return mcp.NewToolResultError(errMessage), nil
+	}
+
+	if dbService == nil {
+		errMessage := "Database service is not initialized"
+		log.Printf("%s", errMessage)
+		return mcp.NewToolResultError(errMessage), nil
+	}
+	// if strings.ContainsAny(strings.ToLower(Query), "explain") {
+	// 	// records, err := dbService.ExecuteReadQuery(ctx, Query, Params, config.Database)
+	// 	// log.Print(records)
+	// 	// log.Print(err)
+	// }
+	// Execute the Cypher query using the database service
+	records, err := dbService.ExecuteReadQuery(ctx, Query, Params, config.Database)
+	if err != nil {
+		log.Printf("Error executing Cypher query: %v", err)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	response, err := dbService.Neo4jRecordsToJSON(records)
+	if err != nil {
+		log.Printf("Error formatting query results: %v", err)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	return mcp.NewToolResultText(response), nil
+}

--- a/internal/tools/read_cypher_spec.go
+++ b/internal/tools/read_cypher_spec.go
@@ -1,0 +1,22 @@
+package tools
+
+import (
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+type ReadCypherInput struct {
+	Query  string         `json:"query" jsonschema:"default=MATCH(n) RETURN n,description=The Cypher query to execute"`
+	Params map[string]any `json:"params" jsonschema:"description=Parameters to pass to the Cypher query"`
+}
+
+func ReadCypherSpec() mcp.Tool {
+	return mcp.NewTool("read-cypher",
+		mcp.WithDescription("read-cypher executes any arbitrary readonly Cypher query against the user-configured Neo4j database."),
+		mcp.WithInputSchema[ReadCypherInput](),
+		mcp.WithTitleAnnotation("Read Cypher"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(true),
+	)
+}

--- a/internal/tools/read_cypher_spec.go
+++ b/internal/tools/read_cypher_spec.go
@@ -11,7 +11,7 @@ type ReadCypherInput struct {
 
 func ReadCypherSpec() mcp.Tool {
 	return mcp.NewTool("read-cypher",
-		mcp.WithDescription("read-cypher executes any arbitrary readonly Cypher query against the user-configured Neo4j database."),
+		mcp.WithDescription("read-cypher can run only read-only Cypher statements. For write operations (CREATE, MERGE, DELETE, SET, etc...), schema/admin commands, or PROFILE queries, use write-cypher instead."),
 		mcp.WithInputSchema[ReadCypherInput](),
 		mcp.WithTitleAnnotation("Read Cypher"),
 		mcp.WithReadOnlyHintAnnotation(true),

--- a/internal/tools/tool_register.go
+++ b/internal/tools/tool_register.go
@@ -16,12 +16,16 @@ type ToolDependencies struct {
 func GetAllTools(deps *ToolDependencies) []server.ServerTool {
 	return []server.ServerTool{
 		{
-			Tool:    RunCypherSpec(),
-			Handler: RunCypherHandler(deps),
-		},
-		{
 			Tool:    GetSchemaSpec(),
 			Handler: GetSchemaHandler(deps),
+		},
+		{
+			Tool:    ReadCypherSpec(),
+			Handler: ReadCypherHandler(deps),
+		},
+		{
+			Tool:    WriteCypherSpec(),
+			Handler: WriteCypherHandler(deps),
 		},
 	}
 }

--- a/internal/tools/write_cypher_handler.go
+++ b/internal/tools/write_cypher_handler.go
@@ -9,14 +9,14 @@ import (
 	"github.com/neo4j/mcp/internal/database"
 )
 
-func RunCypherHandler(deps *ToolDependencies) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func WriteCypherHandler(deps *ToolDependencies) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		return handleRunCypher(ctx, request, deps.DBService, deps.Config)
+		return handleWriteCypher(ctx, request, deps.DBService, deps.Config)
 	}
 }
 
-func handleRunCypher(ctx context.Context, request mcp.CallToolRequest, dbService database.DatabaseService, config *config.Config) (*mcp.CallToolResult, error) {
-	var args RunCypherInput
+func handleWriteCypher(ctx context.Context, request mcp.CallToolRequest, dbService database.DatabaseService, config *config.Config) (*mcp.CallToolResult, error) {
+	var args WriteCypherInput
 	// Bind arguments to the struct
 	if err := request.BindArguments(&args); err != nil {
 		log.Printf("Error binding arguments: %v", err)
@@ -26,9 +26,6 @@ func handleRunCypher(ctx context.Context, request mcp.CallToolRequest, dbService
 	Params := args.Params
 	// debug log -- to be removed at a later stage
 	log.Printf("cypher-query: %s", Query)
-	if Params != nil {
-		log.Printf("cypher-parameters: %v", Params)
-	}
 
 	// Validate that query is not empty
 	if Query == "" {

--- a/internal/tools/write_cypher_handler_test.go
+++ b/internal/tools/write_cypher_handler_test.go
@@ -1,0 +1,260 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/neo4j/mcp/internal/config"
+	"github.com/neo4j/mcp/internal/database/mocks"
+	"github.com/neo4j/neo4j-go-driver/v5/neo4j"
+	"go.uber.org/mock/gomock"
+)
+
+func TestWriteCypherHandler(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	t.Run("successful cypher execution with parameters", func(t *testing.T) {
+		mockDB := mocks.NewMockDatabaseService(ctrl)
+		mockDB.EXPECT().
+			ExecuteWriteQuery(gomock.Any(), "MATCH (n:Person {name: $name}) RETURN n", map[string]any{"name": "Alice"}, "testdb").
+			Return([]*neo4j.Record{}, nil)
+		mockDB.EXPECT().
+			Neo4jRecordsToJSON(gomock.Any()).
+			Return(`[{"n": {"name": "Alice"}}]`, nil)
+
+		deps := &ToolDependencies{
+			Config:    &config.Config{Database: "testdb"},
+			DBService: mockDB,
+		}
+
+		handler := WriteCypherHandler(deps)
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Arguments: map[string]any{
+					"query":  "MATCH (n:Person {name: $name}) RETURN n",
+					"params": map[string]any{"name": "Alice"},
+				},
+			},
+		}
+
+		result, err := handler(context.Background(), request)
+
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if result == nil || result.IsError {
+			t.Error("Expected success result")
+		}
+	})
+
+	t.Run("successful cypher execution without parameters", func(t *testing.T) {
+		mockDB := mocks.NewMockDatabaseService(ctrl)
+		mockDB.EXPECT().
+			ExecuteWriteQuery(gomock.Any(), "MATCH (n) RETURN count(n)", gomock.Nil(), "testdb").
+			Return([]*neo4j.Record{}, nil)
+		mockDB.EXPECT().
+			Neo4jRecordsToJSON(gomock.Any()).
+			Return(`[{"count(n)": 42}]`, nil)
+
+		deps := &ToolDependencies{
+			Config:    &config.Config{Database: "testdb"},
+			DBService: mockDB,
+		}
+
+		handler := WriteCypherHandler(deps)
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Arguments: map[string]any{
+					"query": "MATCH (n) RETURN count(n)",
+				},
+			},
+		}
+
+		result, err := handler(context.Background(), request)
+
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if result == nil || result.IsError {
+			t.Error("Expected success result")
+		}
+	})
+
+	t.Run("invalid arguments binding", func(t *testing.T) {
+		mockDB := mocks.NewMockDatabaseService(ctrl)
+
+		deps := &ToolDependencies{
+			Config:    &config.Config{Database: "testdb"},
+			DBService: mockDB,
+		}
+
+		handler := WriteCypherHandler(deps)
+		// Test with invalid argument structure that should cause BindArguments to fail
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Arguments: "invalid string instead of map",
+			},
+		}
+
+		result, err := handler(context.Background(), request)
+
+		if err != nil {
+			t.Errorf("Expected no error from handler, got: %v", err)
+		}
+		if result == nil || !result.IsError {
+			t.Error("Expected error result for invalid arguments")
+		}
+	})
+
+	t.Run("missing required arguments", func(t *testing.T) {
+		mockDB := mocks.NewMockDatabaseService(ctrl)
+		// The handler should NOT call ExecuteWriteQuery when query is empty
+		// No expectations set for mockDB since it shouldn't be called
+
+		deps := &ToolDependencies{
+			Config:    &config.Config{Database: "testdb"},
+			DBService: mockDB,
+		}
+
+		handler := WriteCypherHandler(deps)
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Arguments: map[string]any{
+					"invalid_field": "value",
+				},
+			},
+		}
+
+		result, err := handler(context.Background(), request)
+
+		if err != nil {
+			t.Errorf("Expected no error from handler, got: %v", err)
+		}
+		// Now the handler should return an error for empty query
+		if result == nil || !result.IsError {
+			t.Error("Expected error result for missing query parameter")
+		}
+	})
+
+	t.Run("empty query parameter", func(t *testing.T) {
+		mockDB := mocks.NewMockDatabaseService(ctrl)
+		// The handler should NOT call ExecuteWriteQuery when query is empty
+		// No expectations set for mockDB since it shouldn't be called
+
+		deps := &ToolDependencies{
+			Config:    &config.Config{Database: "testdb"},
+			DBService: mockDB,
+		}
+
+		handler := WriteCypherHandler(deps)
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Arguments: map[string]any{
+					"query": "",
+				},
+			},
+		}
+
+		result, err := handler(context.Background(), request)
+
+		if err != nil {
+			t.Errorf("Expected no error from handler, got: %v", err)
+		}
+		// Handler should return an error for empty query
+		if result == nil || !result.IsError {
+			t.Error("Expected error result for empty query parameter")
+		}
+	})
+
+	t.Run("nil database service", func(t *testing.T) {
+		deps := &ToolDependencies{
+			Config:    &config.Config{Database: "testdb"},
+			DBService: nil,
+		}
+
+		handler := WriteCypherHandler(deps)
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Arguments: map[string]any{
+					"query": "MATCH (n) RETURN n",
+				},
+			},
+		}
+
+		result, err := handler(context.Background(), request)
+
+		if err != nil {
+			t.Errorf("Expected no error from handler, got: %v", err)
+		}
+		if result == nil || !result.IsError {
+			t.Error("Expected error result for nil database service")
+		}
+	})
+
+	t.Run("database query execution failure", func(t *testing.T) {
+		mockDB := mocks.NewMockDatabaseService(ctrl)
+		mockDB.EXPECT().
+			ExecuteWriteQuery(gomock.Any(), "INVALID CYPHER", gomock.Nil(), "testdb").
+			Return(nil, errors.New("syntax error"))
+
+		deps := &ToolDependencies{
+			Config:    &config.Config{Database: "testdb"},
+			DBService: mockDB,
+		}
+
+		handler := WriteCypherHandler(deps)
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Arguments: map[string]any{
+					"query": "INVALID CYPHER",
+				},
+			},
+		}
+
+		result, err := handler(context.Background(), request)
+
+		if err != nil {
+			t.Errorf("Expected no error from handler, got: %v", err)
+		}
+		if result == nil || !result.IsError {
+			t.Error("Expected error result for query execution failure")
+		}
+	})
+
+	t.Run("JSON formatting failure", func(t *testing.T) {
+		mockDB := mocks.NewMockDatabaseService(ctrl)
+		mockDB.EXPECT().
+			ExecuteWriteQuery(gomock.Any(), "MATCH (n) RETURN n", gomock.Nil(), "testdb").
+			Return([]*neo4j.Record{}, nil)
+		mockDB.EXPECT().
+			Neo4jRecordsToJSON(gomock.Any()).
+			Return("", errors.New("JSON marshaling failed"))
+
+		deps := &ToolDependencies{
+			Config:    &config.Config{Database: "testdb"},
+			DBService: mockDB,
+		}
+
+		handler := WriteCypherHandler(deps)
+		request := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Arguments: map[string]any{
+					"query": "MATCH (n) RETURN n",
+				},
+			},
+		}
+
+		result, err := handler(context.Background(), request)
+
+		if err != nil {
+			t.Errorf("Expected no error from handler, got: %v", err)
+		}
+		if result == nil || !result.IsError {
+			t.Error("Expected error result for JSON formatting failure")
+		}
+	})
+}
+

--- a/internal/tools/write_cypher_spec.go
+++ b/internal/tools/write_cypher_spec.go
@@ -4,16 +4,16 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-type RunCypherInput struct {
+type WriteCypherInput struct {
 	Query  string         `json:"query" jsonschema:"default=MATCH(n) RETURN n,description=The Cypher query to execute"`
 	Params map[string]any `json:"params" jsonschema:"description=Parameters to pass to the Cypher query"`
 }
 
-func RunCypherSpec() mcp.Tool {
-	return mcp.NewTool("run-cypher",
-		mcp.WithDescription("run-cypher executes any arbitrary Cypher query against the user-configured Neo4j database."),
-		mcp.WithInputSchema[RunCypherInput](),
-		mcp.WithTitleAnnotation("Run Cypher"),
+func WriteCypherSpec() mcp.Tool {
+	return mcp.NewTool("write-cypher",
+		mcp.WithDescription("write-cypher executes any arbitrary Cypher query, with write access, against the user-configured Neo4j database."),
+		mcp.WithInputSchema[WriteCypherInput](),
+		mcp.WithTitleAnnotation("Write Cypher"),
 		mcp.WithReadOnlyHintAnnotation(false),
 		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithIdempotentHintAnnotation(false),


### PR DESCRIPTION
Introduce read-cypher and enforce read-only execution by classifying queries with GetQueryType (via EXPLAIN) before running them.

Implementation logic:
- Calls GetQueryType; if it errors, returns a ToolResultError and does not execute the query.
- Rejects any query not classified as "r" and directs the user to use write-cypher for write operations, schema or admin commands, or PROFILE queries.

Some of the above behaviors could cause confusion. For example:
- Admin queries that do not mutate the database/DBMS (e.g., SHOW USERS) are treated as non-read queries.
- EXPLAIN PROFILE queries are treated as non-read queries, even if the statements following "EXPLAIN PROFILE" do not mutate the database.