### PR TITLE
Update example for improved security

### DIFF
--- a/.changes/unreleased/Minor-20251216-162811.yaml
+++ b/.changes/unreleased/Minor-20251216-162811.yaml
@@ -1,7 +1,7 @@
 kind: Minor
 body: |
   In this release, we add the support for HTTP transport mode.
-  - HTTP Server Mode: Run neo4j-mcp as an HTTP server instead of STDIO. Use `--neo4j-transport-mode` http to enable it. Configure the server address with `--neo4j-http-host 0.0.0.0 --neo4j-http-port 8080`.
+  - HTTP Server Mode: Run neo4j-mcp as an HTTP server instead of STDIO. Use `--neo4j-transport-mode` http to enable it. Configure the server address with `--neo4j-http-host 127.0.0.1 --neo4j-http-port 8080`.
   - Per-Request Authentication & CORS: Each HTTP request authenticates independently. Control which clients can connect using `--neo4j-http-allowed-origins https://client.example.com,https://app.example.com` for granular access control.
   - Secure HTTPS Connections: Enable TLS/HTTPS for production. Use `--neo4j-http-tls-enabled` true `--neo4j-http-tls-cert-file /path/to/cert --neo4j-http-tls-key-file /path/to/key` to encrypt server communications.
 time: 2025-12-16T16:28:11.296124Z

--- a/docs/TLS_SETUP.md
+++ b/docs/TLS_SETUP.md
@@ -13,11 +13,13 @@ All certificates must be in **PEM format** (text-based format with `-----BEGIN C
 **Self-Signed Certificates**: Self-signed certificates do not work out of the box with many MCP clients (e.g., VSCode Copilot, Claude Desktop). These clients require certificates signed by a trusted Certificate Authority (CA).
 
 **For Production**: Use certificates from a trusted CA like:
+
 - Let's Encrypt (free, automated)
 - Your organization's internal CA
 - Commercial certificate providers
 
 Self-signed certificates are only suitable for:
+
 - Local development on `localhost`
 - Testing environments with relaxed security checks
 - Development scenarios where you control the client configuration
@@ -183,7 +185,7 @@ For production, use a proper certificate from a Certificate Authority (e.g., Let
 ./bin/neo4j-mcp \
   --neo4j-uri bolt://localhost:7687 \
   --neo4j-transport-mode http \
-  --neo4j-http-host 0.0.0.0 \
+  --neo4j-http-host 127.0.0.1 \
   --neo4j-http-port 443 \
   --neo4j-http-tls-enabled true \
   --neo4j-http-tls-cert-file /etc/letsencrypt/live/your-domain.com/fullchain.pem \


### PR DESCRIPTION
Change the example configuration to use `127.0.0.1` instead of `0.0.0.0` for the HTTP host, enhancing security by limiting access to local connections only.