### PR TITLE
Remove flaky TLS connection test

### DIFF
--- a/internal/server/server_http_test.go
+++ b/internal/server/server_http_test.go
@@ -2,11 +2,7 @@
 package server
 
 import (
-	"context"
 	"crypto/tls"
-	"fmt"
-	"net"
-	"net/http"
 	"testing"
 	"time"
 
@@ -16,21 +12,6 @@ import (
 	"github.com/neo4j/mcp/internal/testutil"
 	"go.uber.org/mock/gomock"
 )
-
-// findFreePort finds and returns an available TCP port on 127.0.0.1.
-// This is useful for tests that need to bind to a specific port.
-func findFreePort(t *testing.T) int {
-	t.Helper()
-
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("Failed to find free port: %v", err)
-	}
-	port := listener.Addr().(*net.TCPAddr).Port
-	listener.Close()
-
-	return port
-}
 
 // TestHTTPServerPortConfiguration verifies that HTTP server port and host config is stored correctly
 func TestHTTPServerPortConfiguration(t *testing.T) {
@@ -171,10 +152,10 @@ func TestHTTPServerTimeoutConstants(t *testing.T) {
 	// Verify timeout constants are defined with expected values
 	// These constants are used in StartHTTPServer() to configure the http.Server
 	tests := []struct {
-		name           string
-		actualValue    time.Duration
-		expectedValue  time.Duration
-		description    string
+		name          string
+		actualValue   time.Duration
+		expectedValue time.Duration
+		description   string
 	}{
 		{
 			name:          "ReadHeaderTimeout",
@@ -270,97 +251,5 @@ func TestBuildTLSConfig(t *testing.T) {
 				t.Error("Expected CipherSuites to be nil (using Go defaults)")
 			}
 		})
-	}
-}
-
-// TestTLSActualConnection verifies end-to-end TLS connectivity with an actual HTTPS request
-func TestTLSActualConnection(t *testing.T) {
-	certPath, keyPath := testutil.GenerateTestTLSCertificate(t)
-	port := findFreePort(t)
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	cfg := &config.Config{
-		URI:             "bolt://test-host:7687",
-		Username:        "test-username",
-		Password:        "test-password",
-		Database:        "neo4j",
-		TransportMode:   config.TransportModeHTTP,
-		HTTPHost:        "127.0.0.1",
-		HTTPPort:        fmt.Sprintf("%d", port),
-		HTTPTLSEnabled:  true,
-		HTTPTLSCertFile: certPath,
-		HTTPTLSKeyFile:  keyPath,
-	}
-
-	// Setup mocks for server initialization
-	mockDB := db.NewMockService(ctrl)
-	analyticsService := analytics.NewMockService(ctrl)
-	analyticsService.EXPECT().NewStartupEvent(gomock.Any()).AnyTimes()
-	analyticsService.EXPECT().EmitEvent(gomock.Any()).AnyTimes()
-
-	srv := NewNeo4jMCPServer("test-version", cfg, mockDB, analyticsService)
-
-	// Start server in background
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- srv.Start()
-	}()
-
-	// Wait for server to be ready
-	<-srv.httpServerReady
-
-	// Get the configured address
-	addr := srv.httpServer.Addr
-
-	// Create HTTPS client that accepts self-signed certificate for testing
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				//nolint:gosec // G402: InsecureSkipVerify is acceptable in tests with self-signed certificates
-				InsecureSkipVerify: true,
-			},
-		},
-		Timeout: 2 * time.Second,
-	}
-
-	// Make an actual HTTPS request
-	resp, err := client.Get(fmt.Sprintf("https://%s/", addr))
-	if err != nil {
-		t.Fatalf("Failed to connect via HTTPS: %v", err)
-	}
-	defer resp.Body.Close()
-
-	// Verify it's using TLS
-	if resp.TLS == nil {
-		t.Fatal("Expected TLS connection, but resp.TLS is nil")
-	}
-
-	// Verify TLS version is 1.2 or higher
-	if resp.TLS.Version < tls.VersionTLS12 {
-		t.Errorf("Expected TLS 1.2+ (0x0303), got 0x%x", resp.TLS.Version)
-	}
-
-	// Log the actual TLS version for debugging
-	tlsVersionName := "unknown"
-	switch resp.TLS.Version {
-	case tls.VersionTLS12:
-		tlsVersionName = "TLS 1.2"
-	case tls.VersionTLS13:
-		tlsVersionName = "TLS 1.3"
-	}
-	t.Logf("Successfully connected via HTTPS using %s", tlsVersionName)
-
-	// Verify handshake was completed
-	if !resp.TLS.HandshakeComplete {
-		t.Error("Expected TLS handshake to be complete")
-	}
-
-	// Cleanup
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	if err := srv.Stop(ctx); err != nil {
-		t.Errorf("Failed to stop server: %v", err)
 	}
 }


### PR DESCRIPTION
Eliminate a test that has been unreliable, improving the overall stability of the test suite.