### PR TITLE
Install CA certificates in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ LABEL io.modelcontextprotocol.server.name="io.github.neo4j/mcp"
 
 WORKDIR /build
 
+# Install CA certificates
+RUN apk add --no-cache ca-certificates
+
 # Copy go mod files
 COPY go.mod go.sum ./
 
@@ -25,6 +28,9 @@ WORKDIR /app
 
 # Copy binary from builder
 COPY --from=builder /build/neo4j-mcp /app/neo4j-mcp
+
+# Copy CA certificates for HTTPS connections
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Run as non-root user (UID 65532 is a standard non-root user ID)
 USER 65532:65532


### PR DESCRIPTION
Add installation of CA certificates in the Dockerfile to support HTTPS connections from Neo4j driver to Aura instances.

Fixes an issue where Aura connections from driver is returning 
```
...ConnectivityError: Unable to retrieve routing table from <neo4j.address>: tls: failed to verify certificate: x509: certificate signed by unknown authority"
```

