### PR TITLE
Separate listener creation from server start

### DIFF
--- a/internal/server/server_http_lifecycle_test.go
+++ b/internal/server/server_http_lifecycle_test.go
@@ -332,12 +332,9 @@ func createHTTPServer(t *testing.T, cfg *config.Config, mockDB *db.MockService, 
 		}
 	}()
 	// wait for HttpServerReady to be closed
+	// Once closed, the port is guaranteed to be bound and listening
 	for range s.HTTPServerReady { //nolint:all // Waiting for channel to close
 	}
-
-	// Give the server a moment to actually bind to the port
-	// The HTTPServerReady channel closes before ListenAndServe() is called
-	time.Sleep(100 * time.Millisecond)
 
 	return s, errChan
 }


### PR DESCRIPTION
Refactor the HTTP server startup process by explicitly creating a listener before starting the server. 

- Separate `net.Listen()` allows for the server to bind the port and indicate (via `HTTPServerReady` chan) server is ready to accept connections
- This allows tests to run deterministically without potential race conditions or manual `time.Sleep()`
- Unit tests are now much faster (from 0.31s to 0.01s)