### PR TITLE
Use container for workflow triggered from forks

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run integration tests
         run: go test -v -tags=integration ./test/integration/...
         env:
-          USE_CONTAINER: ${{ github.event.pull_request.head.repo.full_name == github.repository && "false" || "true" }}
+          USE_CONTAINER: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
           NEO4J_URI: ${{ secrets.AURA_URL }}
           NEO4J_USERNAME: ${{ secrets.AURA_USERNAME }}
           NEO4J_PASSWORD: ${{ secrets.AURA_PASSWORD }}
@@ -96,7 +96,7 @@ jobs:
       - name: Run E2E tests
         run: go test -v -tags=e2e ./test/e2e/...
         env:
-          USE_CONTAINER: ${{ github.event.pull_request.head.repo.full_name == github.repository && "false" || "true" }}
+          USE_CONTAINER: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
           NEO4J_URI: ${{ secrets.AURA_URL }}
           NEO4J_USERNAME: ${{ secrets.AURA_USERNAME }}
           NEO4J_PASSWORD: ${{ secrets.AURA_PASSWORD }}


### PR DESCRIPTION
Set USE_CONTAINER to true when the repository name is different than origin, for case like forks workflows.