### PR TITLE
Skip integration/e2e test when running on forks/container

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,6 +50,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Skip non-ubuntu for forks
+        if: |
+          matrix.os != 'ubuntu-latest' && 
+          github.event.pull_request.head.repo.full_name != github.repository
+        run: echo "Skipping ${{ matrix.os }} for fork PRs"
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Set up Go
@@ -80,6 +85,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Skip non-ubuntu for forks
+        if: |
+          matrix.os != 'ubuntu-latest' && 
+          github.event.pull_request.head.repo.full_name != github.repository
+        run: echo "Skipping ${{ matrix.os }} for fork PRs"
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
       - name: Set up Go


### PR DESCRIPTION
As title, this PR changes the main workflow to skip integration and e2e tests for windows and darwin when workflow is triggered from forks