### PR TITLE
Set USE_CONTAINER correctly for push events on main

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Run integration tests
         run: go test -v -tags=integration ./test/integration/...
         env:
-          USE_CONTAINER: ${{ needs.check-runner.outputs.use-container }}
+          USE_CONTAINER: "false"
           NEO4J_URI: ${{ secrets.AURA_URL }}
           NEO4J_USERNAME: ${{ secrets.AURA_USERNAME }}
           NEO4J_PASSWORD: ${{ secrets.AURA_PASSWORD }}
@@ -172,7 +172,7 @@ jobs:
       - name: Run E2E tests
         run: go test -v -tags=e2e ./test/e2e/...
         env:
-          USE_CONTAINER: ${{ needs.check-runner.outputs.use-container }}
+          USE_CONTAINER: "false"
           NEO4J_URI: ${{ secrets.AURA_URL }}
           NEO4J_USERNAME: ${{ secrets.AURA_USERNAME }}
           NEO4J_PASSWORD: ${{ secrets.AURA_PASSWORD }}


### PR DESCRIPTION
This PR fixes the USE_CONTAINER environment variable logic in the CI workflow.

USE_CONTAINER was only evaluated based on whether the PR came from a fork, but this logic didn't account for push events on main branch, causing incorrect behavior. See: https://github.com/neo4j/mcp/actions/runs/21678984611

We added a dedicated check-runner job to centralize the logic for determining when to use containers
Split integration and E2E test jobs into separate Ubuntu and other OS jobs for testing cross compatibility.
Ubuntu jobs now always run, while Windows/macOS jobs are skipped for fork PRs (when secrets aren't available)
USE_CONTAINER is now properly set via job outputs, correctly handling both PR and push events