### PR TITLE
Support trailing slash for `/mcp` path in middleware

### DIFF
--- a/.changes/unreleased/Patch-20260205-153137.yaml
+++ b/.changes/unreleased/Patch-20260205-153137.yaml
@@ -1,0 +1,3 @@
+kind: Patch
+body: Allow trailing slash for /mcp path
+time: 2026-02-05T15:31:37.333669214Z

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -132,7 +132,7 @@ func pathValidationMiddleware() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Only /mcp path is valid for this MCP server
-			if r.URL.Path != "/mcp" {
+			if r.URL.Path != "/mcp" && r.URL.Path != "/mcp/" {
 				http.Error(w, "Not Found: This server only handles requests to /mcp", http.StatusNotFound)
 				return
 			}

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -560,3 +560,16 @@ func TestPathValidationMiddleware_InFullChain(t *testing.T) {
 		t.Errorf("Expected status 404 for invalid path (before auth check), got %d", rec.Code)
 	}
 }
+
+func TestPathValidationMiddleware_TrailingSlashAllowed(t *testing.T) {
+	handler := pathValidationMiddleware()(mockHandler())
+
+	req := httptest.NewRequest("GET", "/mcp/", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("Expected status 200 for /mcp/ path, got %d", rec.Code)
+	}
+}


### PR DESCRIPTION
resolves half of #173 