### PR TITLE
Fix for when user cannot access neo4j , home / default db is not set

### DIFF
--- a/.changes/v1.4.4.md
+++ b/.changes/v1.4.4.md
@@ -1,0 +1,3 @@
+## v1.4.4 - 2026-02-27
+### Patch
+* Modified VerifyConnectivity in service.go to use a simple harmless query rather than drivers.VerifyConnectivity that can fail in certain scenarios. 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -145,26 +145,14 @@ func parseAllowedOrigins(allowedOriginsStr string) []string {
 func (s *Neo4jMCPServer) verifyRequirements(ctx context.Context) error {
 	err := s.dbService.VerifyConnectivity(ctx)
 	if err != nil {
-		return fmt.Errorf("impossible to verify connectivity with the Neo4j instance: %w", err)
+		return err
 	}
-	// Perform a dummy query to verify correctness of the connection.
-	records, err := s.dbService.ExecuteReadQuery(ctx, "RETURN 1 as first", map[string]any{})
 
-	if err != nil {
-		return fmt.Errorf("impossible to verify connectivity with the Neo4j instance: %w", err)
-	}
-	if len(records) != 1 || len(records[0].Values) != 1 {
-		return fmt.Errorf("failed to verify connectivity with the Neo4j instance: unexpected response from test query")
-	}
-	one, ok := records[0].Values[0].(int64)
-	if !ok || one != 1 {
-		return fmt.Errorf("failed to verify connectivity with the Neo4j instance: unexpected response from test query")
-	}
 	// Check for apoc.meta.schema procedure
 	checkApocMetaSchemaQuery := "SHOW PROCEDURES YIELD name WHERE name = 'apoc.meta.schema' RETURN count(name) > 0 AS apocMetaSchemaAvailable"
 
 	// Check for apoc.meta.schema availability
-	records, err = s.dbService.ExecuteReadQuery(ctx, checkApocMetaSchemaQuery, nil)
+	records, err := s.dbService.ExecuteReadQuery(ctx, checkApocMetaSchemaQuery, nil)
 	if err != nil {
 		return fmt.Errorf("failed to check for APOC availability: %w", err)
 	}


### PR DESCRIPTION
In server.go,

- removed the execution of a simple query 

in service.go  
- VerifyConnectivity now tries to run a simple harmless query to test connectivity and access 
