### PR TITLE
Refactor GH workflows and add quality gate

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,10 +1,7 @@
-name: Build and Test
+name: Neo4j MCP Server tests and linting
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/changie.yml
+++ b/.github/workflows/changie.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - ".changes/unreleased/**"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   check-unreleased:
     runs-on: ubuntu-latest

--- a/.github/workflows/cla-checks.yml
+++ b/.github/workflows/cla-checks.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   cla-check:
     #if: github.event.pull_request.user.login != 'renovate[bot]'

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -6,6 +6,8 @@ on:
     types: [completed]
     branches: [main]
 
+permissions: {}
+
 env:
   DOCKER_REPOSITORY: neo4j/mcp
 

--- a/.github/workflows/licence-checker.yml
+++ b/.github/workflows/licence-checker.yml
@@ -1,9 +1,7 @@
 name: License
 
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,35 @@
+name: Pull request checks
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    uses: ./.github/workflows/build-and-test.yml
+    secrets: inherit
+
+  license:
+    uses: ./.github/workflows/licence-checker.yml
+
+  quality-gate:
+    if: ${{ always() }}
+    needs:
+      - build-and-test
+      - license
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check Job Status
+        run: |
+          if [ "${{ needs.build-and-test.result }}" != 'success' ] ||
+            [ "${{ needs.license.result }}" != 'success' ]; then
+            echo "One or more jobs failed"
+            exit 1
+          else
+            echo "Passed!"
+          fi


### PR DESCRIPTION
Refactors the CI workflows to use a reusable workflow pattern and introduces an explicit quality gate for PR branch protection rulesets.

## Changes

**New: `pull-request-checks.yml`**
Single orchestrator workflow triggered on `pull_request`. Calls `build-and-test.yml` and `licence-checker.yml` as reusable workflows, then runs a `quality-gate` job that can be used as a required status check in a GitHub branch ruleset.

**`build-and-test.yml` / `licence-checker.yml`**
Triggers changed from `push`/`pull_request` to `workflow_call` only. Both workflows are now reusable and invoked exclusively via `pull-request-checks.yml`. This also eliminates the need to special-case conditionally skipped jobs (`integration-tests-other`, `e2e-tests-other`) in the quality gate — skipped inner jobs don't affect the called workflow's overall result.

**`cla-checks.yml`**
Added explicit `permissions: contents: read`. The `pull_request_target` trigger is intentionally preserved: it runs in the base repo context and is the only way to access secrets (e.g. `TEAM_GRAPHQL_PERSONAL_ACCESS_TOKEN`) for fork PRs. This workflow should be registered as a separate required status check in the ruleset alongside `quality-gate`.

**`changie.yml`**
Added `permissions: contents: write` and `pull-requests: write` at the workflow level. Without these, the `generate-pr` job (`peter-evans/create-pull-request`) would fail silently when trying to open the release PR.

**`docker-release.yml`**
Added explicit `permissions: {}` at the workflow level to prevent unintended permission inheritance from repository defaults.
