### PR TITLE
Add MCP name metadata to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- mcp-name: io.github.neo4j/mcp -->
 # Neo4j MCP
 
 Official Model Context Protocol (MCP) server for Neo4j.


### PR DESCRIPTION
This is to allow publishing the MCP Server in the MCP registry started by Anthropic.  

See this Github issue as to why this is required.  

https://github.com/modelcontextprotocol/registry/issues/531