### PR TITLE
[multi-tenant] move verifyRequiments per-request, enable all tools by default.

### DIFF
--- a/.changes/unreleased/Major-20260519-112432.yaml
+++ b/.changes/unreleased/Major-20260519-112432.yaml
@@ -1,5 +1,5 @@
 kind: Major
 body: | 
-  The list-gds-procedures tool is no longer automatically included in the response from the list/tools endpoint.
-  The Initialize request now provides clearer feedback or error messages when requirements are missing or there is a misconfiguration.
+  The list-gds-procedures tool is no longer auto-detected and included in list/tools responses; whether it is exposed now depends on server-level and/or per-request configuration settings.
+  The Initialize request may now fail when connectivity cannot be verified, required plugins (such as APOC) are missing, or configuration is invalid, with descriptive error messages.
 time: 2026-05-19T11:24:32.375014+01:00

--- a/.changes/unreleased/Major-20260519-112432.yaml
+++ b/.changes/unreleased/Major-20260519-112432.yaml
@@ -1,0 +1,5 @@
+kind: Major
+body: | 
+  The list-gds-procedures tool is no longer automatically included in the response from the list/tools endpoint.
+  The Initialize request now provides clearer feedback or error messages when requirements are missing or there is a misconfiguration.
+time: 2026-05-19T11:24:32.375014+01:00

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,7 +3,7 @@
 version: "3"
 
 tasks:
-  # test utils: spass CLI args as task:test -- -v
+  # test utils: pass CLI args as task:test -- -v
   test:
     cmds:
       - go test ./... {{.CLI_ARGS}}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,22 +2,8 @@
 
 version: "3"
 
-dotenv: [".env.task"]
-
 tasks:
-  build:
-    cmds:
-      - go build -C cmd/neo4j-mcp -o ../../bin/ {{.CLI_ARGS}}
-  run:
-    cmds:
-      - go run ./cmd/neo4j-mcp
-  run:compiled:
-    cmds:
-      - ./bin/neo4j-mcp {{.CLI_ARGS}}
-  generate:
-    cmds:
-      - go generate ./...
-  # pass CLI args as task:test -- -v
+  # test utils: spass CLI args as task:test -- -v
   test:
     cmds:
       - go test ./... {{.CLI_ARGS}}
@@ -33,12 +19,32 @@ tasks:
   test:clean:
     cmds:
       - go clean -testcache
+  # build 'n' runs
+  build:
+    cmds:
+      - go build -C cmd/neo4j-mcp -o ../../bin/ {{.CLI_ARGS}}
+  run:
+    dotenv: [".env.task"]
+    cmds:
+      - go run ./cmd/neo4j-mcp
+  run:compiled:
+    dotenv: [".env.task"]
+    cmds:
+      - ./bin/neo4j-mcp {{.CLI_ARGS}}
+  # generation
+  generate:
+    cmds:
+      - go generate ./...
+  # dev tooling
   lint:
     cmds:
       - golangci-lint run
+  # playground 'n' debugging
   inspect:
+    dotenv: [".env.task"]
     cmds:
       - npx @modelcontextprotocol/inspector go run ./cmd/neo4j-mcp
   interactive-client:
+    dotenv: [".env.task"]
     cmds:
       - go run ./client/... bin/neo4j-mcp

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -39,12 +39,11 @@ func mockNeo4jMCPServer(t *testing.T) *Neo4jMCPServer {
 	mcpServer := server.NewMCPServer("test-server", "1.0.0")
 
 	return &Neo4jMCPServer{
-		MCPServer:    mcpServer,
-		config:       cfg,
-		dbService:    mockDBService,
-		anService:    mockAnalyticsService,
-		version:      "1.0.0",
-		gdsInstalled: false,
+		MCPServer: mcpServer,
+		config:    cfg,
+		dbService: mockDBService,
+		anService: mockAnalyticsService,
+		version:   "1.0.0",
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -414,7 +414,7 @@ func (s *Neo4jMCPServer) configureHooks() *server.Hooks {
 
 	hooks.AddAfterCallTool(s.handleToolCallComplete)
 
-	hooks.AddOnRequestInitialization(func(ctx context.Context, id any, message any) error {
+	hooks.AddOnRequestInitialization(func(ctx context.Context, _ any, _ any) error {
 		slog.Info("Initialize request: verifying requirements...")
 		err := s.verifyRequirements(ctx)
 		if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -83,9 +83,7 @@ func NewNeo4jMCPServer(version string, cfg *config.Config, dbService database.Se
 // Start initializes and starts the MCP server
 func (s *Neo4jMCPServer) Start() error {
 	slog.Info("Registering server tools")
-	if err := s.registerTools(); err != nil {
-		return err
-	}
+	s.registerTools()
 	s.emitServerStartupEvent()
 	switch s.config.TransportMode {
 	case config.TransportModeHTTP:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,14 +7,11 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"log"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -38,25 +35,21 @@ const (
 
 // Neo4jMCPServer represents the MCP server instance
 type Neo4jMCPServer struct {
-	MCPServer          *server.MCPServer
-	httpServer         *http.Server
-	HTTPServerReady    chan struct{}
-	shutdownChan       chan struct{}
-	config             *config.Config
-	dbService          database.Service
-	version            string
-	anService          analytics.Service
-	gdsInstalled       bool
-	initMu             sync.Mutex
-	connectionVerified atomic.Bool
-	uriResolver        URIResolver
-	driverRegistry     database.DriverRegistry
+	MCPServer       *server.MCPServer
+	httpServer      *http.Server
+	HTTPServerReady chan struct{}
+	shutdownChan    chan struct{}
+	config          *config.Config
+	dbService       database.Service
+	version         string
+	anService       analytics.Service
+	uriResolver     URIResolver
+	driverRegistry  database.DriverRegistry
 }
 
 // NewNeo4jMCPServer creates a new MCP server instance
 // The config parameter is expected to be already validated
 func NewNeo4jMCPServer(version string, cfg *config.Config, dbService database.Service, anService analytics.Service) *Neo4jMCPServer {
-
 	neo4jServer := &Neo4jMCPServer{
 		HTTPServerReady: make(chan struct{}),
 		shutdownChan:    make(chan struct{}),
@@ -64,7 +57,6 @@ func NewNeo4jMCPServer(version string, cfg *config.Config, dbService database.Se
 		dbService:       dbService,
 		version:         version,
 		anService:       anService,
-		gdsInstalled:    false,
 	}
 
 	if cfg.TransportMode == config.TransportModeHTTP {
@@ -90,38 +82,16 @@ func NewNeo4jMCPServer(version string, cfg *config.Config, dbService database.Se
 
 // Start initializes and starts the MCP server
 func (s *Neo4jMCPServer) Start() error {
-
+	slog.Info("Registering server tools")
+	if err := s.registerTools(); err != nil {
+		return err
+	}
+	s.emitServerStartupEvent()
 	switch s.config.TransportMode {
 	case config.TransportModeHTTP:
-		slog.Info("Registering server tools")
-		if err := s.registerTools(); err != nil {
-			return err
-		}
-		// in case of http mode, the initialization process is delayed until the credentials are available.
-		// when the first client is performing the initialize request then the server perform
-
-		s.emitServerStartupEvent()
-
 		return s.StartHTTPServer()
 	case config.TransportModeStdio:
 		{
-			err := s.verifyRequirements(context.Background())
-			if err != nil {
-				return err
-			}
-
-			// Register tools
-			if err := s.registerTools(); err != nil {
-				return fmt.Errorf("failed to register tools: %w", err)
-			}
-
-			s.emitServerStartupEvent()
-			s.emitConnectionInitializedEvent(context.Background())
-			slog.Info(
-				fmt.Sprintf("Starting Neo4j MCP server version %s in STDIO mode", s.version),
-				"version", s.version,
-			)
-
 			return server.ServeStdio(s.MCPServer)
 		}
 	default:
@@ -169,7 +139,6 @@ func parseAllowedOrigins(allowedOriginsStr string) []string {
 // - A valid connection with a Neo4j instance.
 // - The ability to perform a read query (database name is correctly defined).
 // - Required plugin installed: APOC (specifically apoc.meta.schema as it's used for get-schema)
-// - In case GDS is not installed a flag is set in the server and tools will be registered accordingly
 func (s *Neo4jMCPServer) verifyRequirements(ctx context.Context) error {
 	// Use a timeout to fail fast if the Neo4j instance is unreachable (e.g., TCP connection refused,
 	// DNS failure, network failure). Without this, ExecuteReadQuery can block for minutes waiting for
@@ -208,14 +177,13 @@ func (s *Neo4jMCPServer) verifyRequirements(ctx context.Context) error {
 	records, err = s.dbService.ExecuteReadQuery(ctx, "RETURN gds.version() as gdsVersion", nil)
 	if err != nil {
 		// GDS is optional, so we log a warning and continue, assuming it's not installed.
-		log.Print("Impossible to verify GDS installation.")
-		s.gdsInstalled = false
+		slog.Info("Impossible to verify GDS installation.")
 		return nil
 	}
 	if len(records) == 1 && len(records[0].Values) == 1 {
 		_, ok := records[0].Values[0].(string)
 		if ok {
-			s.gdsInstalled = true
+			slog.Info("GDS capability verified")
 		}
 	}
 
@@ -445,36 +413,16 @@ func (s *Neo4jMCPServer) configureHooks() *server.Hooks {
 	hooks := &server.Hooks{}
 
 	hooks.AddAfterCallTool(s.handleToolCallComplete)
-	if s.config.TransportMode == config.TransportModeHTTP {
-		hooks.AddBeforeInitialize(func(ctx context.Context, _ any, _ *mcp.InitializeRequest) {
-			// if requirements and events are already verified/sent return
-			if s.connectionVerified.Load() {
-				return
-			}
-			// lock
-			s.initMu.Lock()
-			defer s.initMu.Unlock()
 
-			// cover edge case "connectionVerified" stored in between check and lock
-			if s.connectionVerified.Load() {
-				return
-			}
-
-			slog.Info("Verify server requirements...")
-			if err := s.verifyRequirements(ctx); err != nil {
-				slog.Error("Error during verification", "error", err)
-				return
-			}
-
-			if s.gdsInstalled {
-				s.addGDSTools()
-			}
-
-			s.emitConnectionInitializedEvent(ctx)
-
-			s.connectionVerified.Store(true)
-		})
-	}
+	hooks.AddOnRequestInitialization(func(ctx context.Context, id any, message any) error {
+		slog.Info("Initialize request: verifying requirements...")
+		err := s.verifyRequirements(ctx)
+		if err != nil {
+			return err
+		}
+		s.emitConnectionInitializedEvent(ctx)
+		return nil
+	})
 
 	return hooks
 }

--- a/internal/server/server_http_lifecycle_test.go
+++ b/internal/server/server_http_lifecycle_test.go
@@ -127,7 +127,6 @@ func TestNeo4jMCPServerHTTPMode(t *testing.T) {
 			t.Fatalf("error while initialize request: %v", err)
 		}
 		assertNoCloseOrStopError(t, s, errChan)
-
 	})
 
 	t.Run("Server handles database connectivity errors gracefully", func(t *testing.T) {
@@ -142,62 +141,13 @@ func TestNeo4jMCPServerHTTPMode(t *testing.T) {
 		s, errChan := createHTTPServer(t, cfg, mockDB, analyticsService)
 
 		mcpClient := createStreamableHTTPClient(uri)
+		// initialize should fail, while the server should keep working fine.
 		_, err := mcpClient.Initialize(context.Background(), mcp.InitializeRequest{})
-		if err != nil {
+		if err == nil {
 			t.Fatalf("error while initialize request: %v", err)
 		}
+		assert.ErrorContains(t, err, "impossible to verify connectivity with the Neo4j instance: connection error")
 		assertNoCloseOrStopError(t, s, errChan)
-
-	})
-
-	t.Run("Server should not perform duplicate verification calls", func(t *testing.T) {
-		// in HTTP mode once the requirements are check are not checked again, since the configuration are shared across users.
-		// the before initialization hook should not be used as authentication mechanism as it cannot return valid errors to the users.
-		mockDB := db.NewMockService(ctrl)
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "RETURN 1 as first", gomock.Any()).Times(1).Return([]*neo4j.Record{
-			{
-				Keys: []string{"first"},
-				Values: []any{
-					int64(1),
-				},
-			},
-		}, nil)
-		checkApocMetaSchemaQuery := "SHOW PROCEDURES YIELD name WHERE name = 'apoc.meta.schema' RETURN count(name) > 0 AS apocMetaSchemaAvailable"
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), checkApocMetaSchemaQuery, gomock.Any()).Times(1).Return([]*neo4j.Record{
-			{
-				Keys: []string{"apocMetaSchemaAvailable"},
-				Values: []any{
-					bool(true),
-				},
-			},
-		}, nil)
-		gdsVersionQuery := "RETURN gds.version() as gdsVersion"
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), gdsVersionQuery, gomock.Any()).Times(1).Return([]*neo4j.Record{
-			{
-				Keys: []string{"gdsVersion"},
-				Values: []any{
-					string("2.22.0"),
-				},
-			},
-		}, nil)
-
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "CALL dbms.components()", gomock.Any()).Times(1)
-
-		s, errChan := createHTTPServer(t, cfg, mockDB, analyticsService)
-
-		mcpClient := createStreamableHTTPClient(uri)
-		_, err := mcpClient.Initialize(context.Background(), mcp.InitializeRequest{})
-		if err != nil {
-			t.Fatalf("error while initialize request: %v", err)
-		}
-		// create new client to verify that at new requests the verifyRequirements is not preformed again.
-		mcpClient2 := createStreamableHTTPClient(uri)
-		_, err = mcpClient2.Initialize(context.Background(), mcp.InitializeRequest{})
-		if err != nil {
-			t.Fatalf("error while initialize request: %v", err)
-		}
-		assertNoCloseOrStopError(t, s, errChan)
-
 	})
 
 	t.Run("server creates successfully with all required components", func(t *testing.T) {
@@ -246,50 +196,6 @@ func TestNeo4jMCPServerHTTPMode(t *testing.T) {
 			toolNames = append(toolNames, tool.Tool.Name)
 		}
 		assert.Contains(t, toolNames, "list-gds-procedures")
-
-		assertNoCloseOrStopError(t, s, errChan)
-
-	})
-
-	t.Run("server should not add GDS tools when GDS is not installed", func(t *testing.T) {
-		mockDB := db.NewMockService(ctrl)
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "RETURN 1 as first", gomock.Any()).Times(1).Return([]*neo4j.Record{
-			{
-				Keys: []string{"first"},
-				Values: []any{
-					int64(1),
-				},
-			},
-		}, nil)
-		checkApocMetaSchemaQuery := "SHOW PROCEDURES YIELD name WHERE name = 'apoc.meta.schema' RETURN count(name) > 0 AS apocMetaSchemaAvailable"
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), checkApocMetaSchemaQuery, gomock.Any()).Times(1).Return([]*neo4j.Record{
-			{
-				Keys: []string{"apocMetaSchemaAvailable"},
-				Values: []any{
-					bool(true),
-				},
-			},
-		}, nil)
-
-		gdsVersionQuery := "RETURN gds.version() as gdsVersion"
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), gdsVersionQuery, gomock.Any()).Times(1).Return(nil, fmt.Errorf("Unknown function 'gds.version'"))
-
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "CALL dbms.components()", gomock.Any()).Times(1)
-
-		// In HTTP mode, NO database operations should happen during Start()
-		// The hook is registered but not executed until a real client request
-		s, errChan := createHTTPServer(t, cfg, mockDB, analyticsService)
-
-		mcpClient := createStreamableHTTPClient(uri)
-		_, err := mcpClient.Initialize(context.Background(), mcp.InitializeRequest{})
-		if err != nil {
-			t.Fatalf("error while initialize request: %v", err)
-		}
-		toolNames := make([]string, 0, len(s.MCPServer.ListTools()))
-		for _, tool := range s.MCPServer.ListTools() {
-			toolNames = append(toolNames, tool.Tool.Name)
-		}
-		assert.NotContains(t, toolNames, "list-gds-procedures")
 
 		assertNoCloseOrStopError(t, s, errChan)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
 	analyticsReal "github.com/neo4j/mcp/internal/analytics"
 	analytics "github.com/neo4j/mcp/internal/analytics/mocks"
 	"github.com/neo4j/mcp/internal/config"
@@ -37,6 +39,54 @@ func TestNewNeo4jMCPServer(t *testing.T) {
 
 	t.Run("starts server successfully", func(t *testing.T) {
 		mockDB := db.NewMockService(ctrl)
+
+		s := server.NewNeo4jMCPServer("test-version", cfg, mockDB, analyticsService)
+
+		if s == nil {
+			t.Errorf("NewNeo4jMCPServer() expected non-nil server, got nil")
+		}
+
+		err := s.Start()
+
+		if err != nil {
+			t.Errorf("Start() unexpected error = %v", err)
+		}
+	})
+	t.Run("stops server successfully", func(t *testing.T) {
+		mockDB := db.NewMockService(ctrl)
+
+		s := server.NewNeo4jMCPServer("test-version", cfg, mockDB, analyticsService)
+
+		if s == nil {
+			t.Errorf("NewNeo4jMCPServer() expected non-nil server, got nil")
+		}
+
+		err := s.Start()
+		if err != nil {
+			t.Errorf("Start() unexpected error = %v", err)
+		}
+	})
+}
+
+func TestInitializeRequestHook(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfg := &config.Config{
+		URI:           "bolt://test-host:7687",
+		Username:      "neo4j",
+		Password:      "password",
+		Database:      "neo4j",
+		TransportMode: config.TransportModeStdio,
+	}
+
+	analyticsService := analytics.NewMockService(ctrl)
+	analyticsService.EXPECT().IsEnabled().AnyTimes().Return(true)
+	analyticsService.EXPECT().EmitEvent(gomock.Any()).AnyTimes()
+	analyticsService.EXPECT().NewStartupEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	analyticsService.EXPECT().NewConnectionInitializedEvent(gomock.Any()).AnyTimes()
+	t.Run("initialize succesful", func(t *testing.T) {
+		mockDB := db.NewMockService(ctrl)
 		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "RETURN 1 as first", gomock.Any()).Times(1).Return([]*neo4j.Record{
 			{
 				Keys: []string{"first"},
@@ -63,22 +113,25 @@ func TestNewNeo4jMCPServer(t *testing.T) {
 				},
 			},
 		}, nil)
-
 		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "CALL dbms.components()", gomock.Any()).Times(1)
-
 		s := server.NewNeo4jMCPServer("test-version", cfg, mockDB, analyticsService)
 
 		if s == nil {
 			t.Errorf("NewNeo4jMCPServer() expected non-nil server, got nil")
 		}
-
-		err := s.Start()
-
+		var startErr error
+		go func() {
+			startErr = s.Start()
+		}()
+		if startErr != nil {
+			t.Errorf("error while starting the MCP Server")
+		}
+		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
+		_, err = inProcessClient.Initialize(context.Background(), mcp.InitializeRequest{})
 		if err != nil {
-			t.Errorf("Start() unexpected error = %v", err)
+			t.Fatalf("Expect no error during initialization, got: %s", err.Error())
 		}
 	})
-
 	t.Run("starts server should fails when no connection can be established", func(t *testing.T) {
 		mockDB := db.NewMockService(ctrl)
 		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil, fmt.Errorf("connection error"))
@@ -87,11 +140,19 @@ func TestNewNeo4jMCPServer(t *testing.T) {
 		if s == nil {
 			t.Errorf("NewNeo4jMCPServer() expected non-nil server, got nil")
 		}
-
-		err := s.Start()
-		if err == nil {
-			t.Errorf("Start() expected an error, got nil")
+		var startErr error
+		go func() {
+			startErr = s.Start()
+		}()
+		if startErr != nil {
+			t.Errorf("error while starting the MCP Server")
 		}
+		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
+		_, err = inProcessClient.Initialize(context.Background(), mcp.InitializeRequest{})
+		if err == nil {
+			t.Fatal("Expect error during initialization, when no connection can be established, go nil")
+		}
+
 	})
 	t.Run("starts server should fail when test query returns unexpected result", func(t *testing.T) {
 		mockDB := db.NewMockService(ctrl)
@@ -107,59 +168,17 @@ func TestNewNeo4jMCPServer(t *testing.T) {
 			t.Errorf("NewNeo4jMCPServer() expected non-nil server, got nil")
 		}
 
-		err := s.Start()
+		var startErr error
+		go func() {
+			startErr = s.Start()
+		}()
+		if startErr != nil {
+			t.Errorf("error while starting the MCP Server")
+		}
+		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
+		_, err = inProcessClient.Initialize(context.Background(), mcp.InitializeRequest{})
 		if err == nil {
-			t.Errorf("Start() expected an error for unexpected query result, got nil")
-		}
-	})
-
-	t.Run("server creates successfully with all required components", func(t *testing.T) {
-		mockDB := db.NewMockService(ctrl)
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "RETURN 1 as first", gomock.Any()).Times(1).Return([]*neo4j.Record{
-			{
-				Keys: []string{"first"},
-				Values: []any{
-					int64(1),
-				},
-			},
-		}, nil)
-		checkApocMetaSchemaQuery := "SHOW PROCEDURES YIELD name WHERE name = 'apoc.meta.schema' RETURN count(name) > 0 AS apocMetaSchemaAvailable"
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), checkApocMetaSchemaQuery, gomock.Any()).Times(1).Return([]*neo4j.Record{
-			{
-				Keys: []string{"apocMetaSchemaAvailable"},
-				Values: []any{
-					bool(true),
-				},
-			},
-		}, nil)
-		gdsVersionQuery := "RETURN gds.version() as gdsVersion"
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), gdsVersionQuery, gomock.Any()).Times(1).Return([]*neo4j.Record{
-			{
-				Keys: []string{"gdsVersion"},
-				Values: []any{
-					string("2.22.0"),
-				},
-			},
-		}, nil)
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "CALL dbms.components()", gomock.Any()).Times(1)
-
-		s := server.NewNeo4jMCPServer("test-version", cfg, mockDB, analyticsService)
-
-		if s == nil {
-			t.Fatal("NewNeo4jMCPServer() returned nil")
-		}
-
-		// Start should work without errors
-		err := s.Start()
-		if err != nil {
-			t.Errorf("Start() unexpected error = %v", err)
-		}
-
-		// Stop should work without errors
-		ctx := context.Background()
-		err = s.Stop(ctx)
-		if err != nil {
-			t.Errorf("Stop() unexpected error = %v", err)
+			t.Fatal("Expect error during initialization, when unexpected results are returned, go nil")
 		}
 	})
 
@@ -191,56 +210,24 @@ func TestNewNeo4jMCPServer(t *testing.T) {
 		if s == nil {
 			t.Errorf("NewNeo4jMCPServer() expected non-nil server, got nil")
 		}
-		err := s.Start()
-		if err != nil {
-			t.Errorf("Start() unexpected error = %v", err)
+		var startErr error
+		go func() {
+			startErr = s.Start()
+		}()
+		if startErr != nil {
+			t.Errorf("error while starting the MCP Server")
 		}
-	})
-
-	t.Run("stops server successfully", func(t *testing.T) {
-		mockDB := db.NewMockService(ctrl)
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "RETURN 1 as first", gomock.Any()).Times(1).Return([]*neo4j.Record{
-			{
-				Keys: []string{"first"},
-				Values: []any{
-					int64(1),
-				},
-			},
-		}, nil)
-		checkApocMetaSchemaQuery := "SHOW PROCEDURES YIELD name WHERE name = 'apoc.meta.schema' RETURN count(name) > 0 AS apocMetaSchemaAvailable"
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), checkApocMetaSchemaQuery, gomock.Any()).Times(1).Return([]*neo4j.Record{
-			{
-				Keys: []string{"apocMetaSchemaAvailable"},
-				Values: []any{
-					bool(true),
-				},
-			},
-		}, nil)
-		gdsVersionQuery := "RETURN gds.version() as gdsVersion"
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), gdsVersionQuery, gomock.Any()).Times(1).Return([]*neo4j.Record{
-			{
-				Keys: []string{"gdsVersion"},
-				Values: []any{
-					string("2.22.0"),
-				},
-			},
-		}, nil)
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "CALL dbms.components()", gomock.Any()).Times(1)
-
-		s := server.NewNeo4jMCPServer("test-version", cfg, mockDB, analyticsService)
-
-		if s == nil {
-			t.Errorf("NewNeo4jMCPServer() expected non-nil server, got nil")
-		}
-
-		err := s.Start()
+		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
+		_, err = inProcessClient.Initialize(context.Background(), mcp.InitializeRequest{})
 		if err != nil {
-			t.Errorf("Start() unexpected error = %v", err)
+			t.Fatalf("Expect no error during initialization, got: %s", err.Error())
 		}
 	})
 }
 
 func TestNewNeo4jMCPServerEvents(t *testing.T) {
+	t.Skip()
+	// move to initialize tests
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -306,6 +293,7 @@ func TestNewNeo4jMCPServerEvents(t *testing.T) {
 			t.Fatal("NewNeo4jMCPServer() returned nil")
 		}
 		err := s.Start()
+
 		if err != nil {
 			t.Errorf("Start() unexpected error = %v", err)
 		}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -228,7 +228,7 @@ func TestInitializeRequestHook(t *testing.T) {
 		}
 		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
 		if err != nil {
-			t.Fatalf("Unexpected error during InProcesClient creation, %s", err.Error())
+			t.Fatalf("Unexpected error during InProcessClient creation, %s", err.Error())
 		}
 		_, err = inProcessClient.Initialize(context.Background(), mcp.InitializeRequest{})
 		if err != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -125,7 +125,7 @@ func TestInitializeRequestHook(t *testing.T) {
 		}
 		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
 		if err != nil {
-			t.Fatalf("Unexpected error during InProcesClient creation, %s", err.Error())
+			t.Fatalf("Unexpected error during InProcessClient creation, %s", err.Error())
 		}
 		_, err = inProcessClient.Initialize(context.Background(), mcp.InitializeRequest{})
 		if err != nil {
@@ -146,7 +146,7 @@ func TestInitializeRequestHook(t *testing.T) {
 		}
 		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
 		if err != nil {
-			t.Fatalf("Unexpected error during InProcesClient creation, %s", err.Error())
+			t.Fatalf("Unexpected error during InProcessClient creation, %s", err.Error())
 		}
 		_, err = inProcessClient.Initialize(context.Background(), mcp.InitializeRequest{})
 		if err == nil {
@@ -174,7 +174,7 @@ func TestInitializeRequestHook(t *testing.T) {
 		}
 		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
 		if err != nil {
-			t.Fatalf("Unexpected error during InProcesClient creation, %s", err.Error())
+			t.Fatalf("Unexpected error during InProcessClient creation, %s", err.Error())
 		}
 		_, err = inProcessClient.Initialize(context.Background(), mcp.InitializeRequest{})
 		if err == nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -43,7 +43,7 @@ func TestNewNeo4jMCPServer(t *testing.T) {
 		s := server.NewNeo4jMCPServer("test-version", cfg, mockDB, analyticsService)
 
 		if s == nil {
-			t.Errorf("NewNeo4jMCPServer() expected non-nil server, got nil")
+			t.Fatal("NewNeo4jMCPServer() expected non-nil server, got nil")
 		}
 
 		err := s.Start()
@@ -58,7 +58,7 @@ func TestNewNeo4jMCPServer(t *testing.T) {
 		s := server.NewNeo4jMCPServer("test-version", cfg, mockDB, analyticsService)
 
 		if s == nil {
-			t.Errorf("NewNeo4jMCPServer() expected non-nil server, got nil")
+			t.Fatal("NewNeo4jMCPServer() expected non-nil server, got nil")
 		}
 
 		err := s.Start()
@@ -117,7 +117,7 @@ func TestInitializeRequestHook(t *testing.T) {
 		s := server.NewNeo4jMCPServer("test-version", cfg, mockDB, analyticsService)
 
 		if s == nil {
-			t.Errorf("NewNeo4jMCPServer() expected non-nil server, got nil")
+			t.Fatal("NewNeo4jMCPServer() expected non-nil server, got nil")
 		}
 		err := s.Start()
 		if err != nil {
@@ -138,7 +138,7 @@ func TestInitializeRequestHook(t *testing.T) {
 		s := server.NewNeo4jMCPServer("test-version", cfg, mockDB, analyticsService)
 
 		if s == nil {
-			t.Errorf("NewNeo4jMCPServer() expected non-nil server, got nil")
+			t.Fatal("NewNeo4jMCPServer() expected non-nil server, got nil")
 		}
 		err := s.Start()
 		if err != nil {
@@ -165,7 +165,7 @@ func TestInitializeRequestHook(t *testing.T) {
 		s := server.NewNeo4jMCPServer("test-version", cfg, mockDB, analyticsService)
 
 		if s == nil {
-			t.Errorf("NewNeo4jMCPServer() expected non-nil server, got nil")
+			t.Fatal("NewNeo4jMCPServer() expected non-nil server, got nil")
 		}
 
 		err := s.Start()
@@ -208,7 +208,7 @@ func TestInitializeRequestHook(t *testing.T) {
 		s := server.NewNeo4jMCPServer("test-version", cfg, mockDB, analyticsService)
 
 		if s == nil {
-			t.Errorf("NewNeo4jMCPServer() expected non-nil server, got nil")
+			t.Fatal("NewNeo4jMCPServer() expected non-nil server, got nil")
 		}
 
 		err := s.Start()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -119,11 +119,8 @@ func TestInitializeRequestHook(t *testing.T) {
 		if s == nil {
 			t.Errorf("NewNeo4jMCPServer() expected non-nil server, got nil")
 		}
-		var startErr error
-		go func() {
-			startErr = s.Start()
-		}()
-		if startErr != nil {
+		err := s.Start()
+		if err != nil {
 			t.Errorf("error while starting the MCP Server")
 		}
 		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
@@ -143,11 +140,8 @@ func TestInitializeRequestHook(t *testing.T) {
 		if s == nil {
 			t.Errorf("NewNeo4jMCPServer() expected non-nil server, got nil")
 		}
-		var startErr error
-		go func() {
-			startErr = s.Start()
-		}()
-		if startErr != nil {
+		err := s.Start()
+		if err != nil {
 			t.Errorf("error while starting the MCP Server")
 		}
 		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
@@ -156,7 +150,7 @@ func TestInitializeRequestHook(t *testing.T) {
 		}
 		_, err = inProcessClient.Initialize(context.Background(), mcp.InitializeRequest{})
 		if err == nil {
-			t.Fatal("Expect error during initialization, when no connection can be established, go nil")
+			t.Fatal("Expect error during initialization, when no connection can be established, got nil")
 		}
 
 	})
@@ -174,11 +168,8 @@ func TestInitializeRequestHook(t *testing.T) {
 			t.Errorf("NewNeo4jMCPServer() expected non-nil server, got nil")
 		}
 
-		var startErr error
-		go func() {
-			startErr = s.Start()
-		}()
-		if startErr != nil {
+		err := s.Start()
+		if err != nil {
 			t.Errorf("error while starting the MCP Server")
 		}
 		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
@@ -187,7 +178,7 @@ func TestInitializeRequestHook(t *testing.T) {
 		}
 		_, err = inProcessClient.Initialize(context.Background(), mcp.InitializeRequest{})
 		if err == nil {
-			t.Fatal("Expect error during initialization, when unexpected results are returned, go nil")
+			t.Fatal("Expect error during initialization, when unexpected results are returned, got nil")
 		}
 	})
 
@@ -219,11 +210,10 @@ func TestInitializeRequestHook(t *testing.T) {
 		if s == nil {
 			t.Errorf("NewNeo4jMCPServer() expected non-nil server, got nil")
 		}
-		var startErr error
-		go func() {
-			startErr = s.Start()
-		}()
-		if startErr != nil {
+
+		err := s.Start()
+
+		if err != nil {
 			t.Errorf("error while starting the MCP Server")
 		}
 		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
@@ -238,7 +228,6 @@ func TestInitializeRequestHook(t *testing.T) {
 }
 
 func TestNewNeo4jMCPServerEvents(t *testing.T) {
-	t.Skip()
 	// move to initialize tests
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -290,7 +279,7 @@ func TestNewNeo4jMCPServerEvents(t *testing.T) {
 	}, nil)
 	analyticsService := analytics.NewMockService(ctrl)
 
-	t.Run("emits startup and OSInfoEvent and StartupEvent events on start", func(t *testing.T) {
+	t.Run("emits ConnectionInitializedEvent and StartupEvent events on initialize", func(t *testing.T) {
 		analyticsService.EXPECT().IsEnabled().Times(1).Return(true)
 		analyticsService.EXPECT().NewStartupEvent(config.TransportModeStdio, false, "test-version").Times(1)
 		analyticsService.EXPECT().NewConnectionInitializedEvent(analyticsReal.ConnectionEventInfo{
@@ -308,6 +297,14 @@ func TestNewNeo4jMCPServerEvents(t *testing.T) {
 
 		if err != nil {
 			t.Errorf("Start() unexpected error = %v", err)
+		}
+		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
+		if err != nil {
+			t.Fatalf("Unexpected error during InProcessClient creation, %s", err.Error())
+		}
+		_, err = inProcessClient.Initialize(context.Background(), mcp.InitializeRequest{})
+		if err != nil {
+			t.Fatalf("Expect no error during initialization, got: %s", err.Error())
 		}
 		// Stop should work without errors
 		ctx := context.Background()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -85,7 +85,7 @@ func TestInitializeRequestHook(t *testing.T) {
 	analyticsService.EXPECT().EmitEvent(gomock.Any()).AnyTimes()
 	analyticsService.EXPECT().NewStartupEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	analyticsService.EXPECT().NewConnectionInitializedEvent(gomock.Any()).AnyTimes()
-	t.Run("initialize succesful", func(t *testing.T) {
+	t.Run("initialize successful", func(t *testing.T) {
 		mockDB := db.NewMockService(ctrl)
 		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "RETURN 1 as first", gomock.Any()).Times(1).Return([]*neo4j.Record{
 			{
@@ -127,6 +127,9 @@ func TestInitializeRequestHook(t *testing.T) {
 			t.Errorf("error while starting the MCP Server")
 		}
 		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
+		if err != nil {
+			t.Fatalf("Unexpected error during InProcesClient creation, %s", err.Error())
+		}
 		_, err = inProcessClient.Initialize(context.Background(), mcp.InitializeRequest{})
 		if err != nil {
 			t.Fatalf("Expect no error during initialization, got: %s", err.Error())
@@ -148,6 +151,9 @@ func TestInitializeRequestHook(t *testing.T) {
 			t.Errorf("error while starting the MCP Server")
 		}
 		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
+		if err != nil {
+			t.Fatalf("Unexpected error during InProcesClient creation, %s", err.Error())
+		}
 		_, err = inProcessClient.Initialize(context.Background(), mcp.InitializeRequest{})
 		if err == nil {
 			t.Fatal("Expect error during initialization, when no connection can be established, go nil")
@@ -176,6 +182,9 @@ func TestInitializeRequestHook(t *testing.T) {
 			t.Errorf("error while starting the MCP Server")
 		}
 		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
+		if err != nil {
+			t.Fatalf("Unexpected error during InProcesClient creation, %s", err.Error())
+		}
 		_, err = inProcessClient.Initialize(context.Background(), mcp.InitializeRequest{})
 		if err == nil {
 			t.Fatal("Expect error during initialization, when unexpected results are returned, go nil")
@@ -218,6 +227,9 @@ func TestInitializeRequestHook(t *testing.T) {
 			t.Errorf("error while starting the MCP Server")
 		}
 		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
+		if err != nil {
+			t.Fatalf("Unexpected error during InProcesClient creation, %s", err.Error())
+		}
 		_, err = inProcessClient.Initialize(context.Background(), mcp.InitializeRequest{})
 		if err != nil {
 			t.Fatalf("Expect no error during initialization, got: %s", err.Error())

--- a/internal/server/tool_register_test.go
+++ b/internal/server/tool_register_test.go
@@ -4,14 +4,12 @@
 package server_test
 
 import (
-	"fmt"
 	"testing"
 
 	analytics "github.com/neo4j/mcp/internal/analytics/mocks"
 	"github.com/neo4j/mcp/internal/config"
 	db "github.com/neo4j/mcp/internal/database/mocks"
 	"github.com/neo4j/mcp/internal/server"
-	"github.com/neo4j/neo4j-go-driver/v6/neo4j"
 	"go.uber.org/mock/gomock"
 )
 
@@ -23,11 +21,14 @@ func TestToolRegister(t *testing.T) {
 	aService.EXPECT().IsEnabled().AnyTimes().Return(true)
 	aService.EXPECT().EmitEvent(gomock.Any()).AnyTimes()
 	aService.EXPECT().NewStartupEvent(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-	aService.EXPECT().NewConnectionInitializedEvent(gomock.Any()).AnyTimes()
-
+	// Verify no db calls during tool registration
+	mockDB := db.NewMockService(ctrl)
+	mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	mockDB.EXPECT().ExecuteWriteQuery(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	mockDB.EXPECT().GetQueryType(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	mockDB.EXPECT().Neo4jRecordsToJSON(gomock.Any()).Times(0)
 	t.Run("verifies expected tools are registered", func(t *testing.T) {
-		mockDB := getMockedDBService(ctrl, true)
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "CALL dbms.components()", gomock.Any()).Times(1)
+
 		cfg := &config.Config{
 			URI:           "bolt://test-host:7687",
 			Username:      "neo4j",
@@ -55,8 +56,6 @@ func TestToolRegister(t *testing.T) {
 	})
 
 	t.Run("should register only readonly tools when readonly", func(t *testing.T) {
-		mockDB := getMockedDBService(ctrl, true)
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "CALL dbms.components()", gomock.Any()).Times(1)
 		cfg := &config.Config{
 			URI:           "bolt://test-host:7687",
 			Username:      "neo4j",
@@ -83,9 +82,7 @@ func TestToolRegister(t *testing.T) {
 			t.Errorf("Expected %d tools, but test configuration shows %d", expectedTotalToolsCount, registeredTools)
 		}
 	})
-	t.Run("should register also not write tools when readonly is set to false", func(t *testing.T) {
-		mockDB := getMockedDBService(ctrl, true)
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "CALL dbms.components()", gomock.Any()).Times(1)
+	t.Run("should register also write tools when readonly is set to false", func(t *testing.T) {
 		cfg := &config.Config{
 			URI:           "bolt://test-host:7687",
 			Username:      "neo4j",
@@ -113,70 +110,4 @@ func TestToolRegister(t *testing.T) {
 		}
 	})
 
-	t.Run("should remove GDS tools if GDS is not present", func(t *testing.T) {
-		mockDB := getMockedDBService(ctrl, false)
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "CALL dbms.components()", gomock.Any()).Times(1)
-		cfg := &config.Config{
-			URI:           "bolt://test-host:7687",
-			Username:      "neo4j",
-			Password:      "password",
-			Database:      "neo4j",
-			ReadOnly:      false,
-			TransportMode: config.TransportModeStdio,
-		}
-		s := server.NewNeo4jMCPServer("test-version", cfg, mockDB, aService)
-
-		// Expected tools that should be registered
-		// update this number when a tool is added or removed.
-		// Non-GDS tools: get-schema, read-cypher, write-cypher
-		expectedTotalToolsCount := 3
-
-		// Start server and register tools
-		err := s.Start()
-		if err != nil {
-			t.Fatalf("Start() failed: %v", err)
-		}
-		registeredTools := len(s.MCPServer.ListTools())
-
-		if expectedTotalToolsCount != registeredTools {
-			t.Errorf("Expected %d tools, but test configuration shows %d", expectedTotalToolsCount, registeredTools)
-		}
-	})
-}
-
-// utility to mock the invocation required by VerifyRequirements
-func getMockedDBService(ctrl *gomock.Controller, withGDS bool) *db.MockService {
-	mockDB := db.NewMockService(ctrl)
-	mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "RETURN 1 as first", gomock.Any()).Times(1).Return([]*neo4j.Record{
-		{
-			Keys: []string{"first"},
-			Values: []any{
-				int64(1),
-			},
-		},
-	}, nil)
-	checkApocMetaSchemaQuery := "SHOW PROCEDURES YIELD name WHERE name = 'apoc.meta.schema' RETURN count(name) > 0 AS apocMetaSchemaAvailable"
-	mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), checkApocMetaSchemaQuery, gomock.Any()).Times(1).Return([]*neo4j.Record{
-		{
-			Keys: []string{"apocMetaSchemaAvailable"},
-			Values: []any{
-				bool(true),
-			},
-		},
-	}, nil)
-	gdsVersionQuery := "RETURN gds.version() as gdsVersion"
-	if withGDS {
-		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), gdsVersionQuery, gomock.Any()).Times(1).Return([]*neo4j.Record{
-			{
-				Keys: []string{"gdsVersion"},
-				Values: []any{
-					string("2.22.0"),
-				},
-			},
-		}, nil)
-		return mockDB
-	}
-	mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), gdsVersionQuery, gomock.Any()).Times(1).Return(nil, fmt.Errorf("Unknown function 'gds.version'"))
-
-	return mockDB
 }

--- a/internal/server/tools_register.go
+++ b/internal/server/tools_register.go
@@ -37,10 +37,8 @@ func (s *Neo4jMCPServer) getTools() []server.ServerTool {
 		if s.config.ReadOnly && !toolDef.readonly {
 			continue
 		}
-		serverTools = append(serverTools, server.ServerTool{
-			Tool:    toolDef.definition.Tool,
-			Handler: toolDef.definition.Handler,
-		})
+
+		serverTools = append(serverTools, toolDef.definition)
 	}
 	return serverTools
 }

--- a/internal/server/tools_register.go
+++ b/internal/server/tools_register.go
@@ -16,10 +16,9 @@ import (
 // any tool that performs state mutation will be excluded; only tools annotated as read-only will be registered.
 // Note: this read-only filtering relies on the tool annotation "readonly" (ReadOnlyHint). If the annotation
 // is not defined or is set to false, the tool will be added (i.e., only tools with readonly=true are filtered in read-only mode).
-func (s *Neo4jMCPServer) registerTools() error {
+func (s *Neo4jMCPServer) registerTools() {
 	tools := s.getTools()
 	s.MCPServer.AddTools(tools...)
-	return nil
 }
 
 type ToolDefinition struct {

--- a/internal/server/tools_register.go
+++ b/internal/server/tools_register.go
@@ -17,98 +17,39 @@ import (
 // Note: this read-only filtering relies on the tool annotation "readonly" (ReadOnlyHint). If the annotation
 // is not defined or is set to false, the tool will be added (i.e., only tools with readonly=true are filtered in read-only mode).
 func (s *Neo4jMCPServer) registerTools() error {
-	filteredTools := s.getEnabledTools()
-	s.MCPServer.AddTools(filteredTools...)
+	tools := s.getTools()
+	s.MCPServer.AddTools(tools...)
 	return nil
 }
 
-type toolFilter func(tools []ToolDefinition) []ToolDefinition
-
-type toolCategory int
-
-const (
-	cypherCategory toolCategory = 0
-	gdsCategory    toolCategory = 1
-)
-
 type ToolDefinition struct {
-	category   toolCategory
 	definition server.ServerTool
 	readonly   bool
 }
 
-func (s *Neo4jMCPServer) addGDSTools() {
+func (s *Neo4jMCPServer) getTools() []server.ServerTool {
 	deps := &tools.ToolDependencies{
 		DBService:        s.dbService,
 		AnalyticsService: s.anService,
 	}
-	toolDefs := s.getAllToolsDefs(deps)
-	toolDefinition := make([]server.ServerTool, 0)
-	GDSTools := make([]ToolDefinition, 0, len(toolDefs))
-	for _, t := range toolDefs {
-		if t.category == gdsCategory {
-			GDSTools = append(GDSTools, t)
+	toolsDefs := s.getAllToolsDefs(deps)
+	serverTools := make([]server.ServerTool, 0, len(toolsDefs))
+	for _, toolDef := range toolsDefs {
+		if s.config.ReadOnly && !toolDef.readonly {
+			continue
 		}
+		serverTools = append(serverTools, server.ServerTool{
+			Tool:    toolDef.definition.Tool,
+			Handler: toolDef.definition.Handler,
+		})
 	}
-	for _, toolDef := range GDSTools {
-		toolDefinition = append(toolDefinition, toolDef.definition)
-	}
-	s.MCPServer.AddTools(toolDefinition...)
-}
-
-func (s *Neo4jMCPServer) getEnabledTools() []server.ServerTool {
-	filters := make([]toolFilter, 0)
-
-	// If read-only mode is enabled, expose only tools annotated as read-only.
-	if s.config != nil && s.config.ReadOnly {
-		filters = append(filters, filterWriteTools)
-	}
-	// If GDS is not installed, disable GDS tools.
-	if !s.gdsInstalled {
-		filters = append(filters, filterGDSTools)
-	}
-	deps := &tools.ToolDependencies{
-		DBService:        s.dbService,
-		AnalyticsService: s.anService,
-	}
-	toolDefs := s.getAllToolsDefs(deps)
-
-	for _, filter := range filters {
-		toolDefs = filter(toolDefs)
-	}
-	enabledTools := make([]server.ServerTool, 0)
-	for _, toolDef := range toolDefs {
-		enabledTools = append(enabledTools, toolDef.definition)
-	}
-	return enabledTools
-}
-
-func filterWriteTools(tools []ToolDefinition) []ToolDefinition {
-	readOnlyTools := make([]ToolDefinition, 0, len(tools))
-	for _, t := range tools {
-		if t.readonly {
-			readOnlyTools = append(readOnlyTools, t)
-		}
-	}
-	return readOnlyTools
-}
-
-func filterGDSTools(tools []ToolDefinition) []ToolDefinition {
-	nonGDSTools := make([]ToolDefinition, 0, len(tools))
-	for _, t := range tools {
-		if t.category != gdsCategory {
-			nonGDSTools = append(nonGDSTools, t)
-		}
-	}
-	return nonGDSTools
+	return serverTools
 }
 
 // getAllToolsDefs returns all available tools with their specs and handlers
 func (s *Neo4jMCPServer) getAllToolsDefs(deps *tools.ToolDependencies) []ToolDefinition {
-
 	return []ToolDefinition{
 		{
-			category: cypherCategory,
 			definition: server.ServerTool{
 				Tool:    cypher.GetSchemaSpec(),
 				Handler: cypher.GetSchemaHandler(deps, s.config.SchemaSampleSize),
@@ -116,7 +57,6 @@ func (s *Neo4jMCPServer) getAllToolsDefs(deps *tools.ToolDependencies) []ToolDef
 			readonly: true,
 		},
 		{
-			category: cypherCategory,
 			definition: server.ServerTool{
 				Tool:    cypher.ReadCypherSpec(),
 				Handler: cypher.ReadCypherHandler(deps),
@@ -124,7 +64,6 @@ func (s *Neo4jMCPServer) getAllToolsDefs(deps *tools.ToolDependencies) []ToolDef
 			readonly: true,
 		},
 		{
-			category: cypherCategory,
 			definition: server.ServerTool{
 				Tool:    cypher.WriteCypherSpec(),
 				Handler: cypher.WriteCypherHandler(deps),
@@ -133,7 +72,6 @@ func (s *Neo4jMCPServer) getAllToolsDefs(deps *tools.ToolDependencies) []ToolDef
 		},
 		// GDS Category/Section
 		{
-			category: gdsCategory,
 			definition: server.ServerTool{
 				Tool:    gds.ListGDSProceduresSpec(),
 				Handler: gds.ListGdsProceduresHandler(deps),

--- a/test/e2e/healthz_test.go
+++ b/test/e2e/healthz_test.go
@@ -7,103 +7,20 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 	"io"
-	"net"
 	"net/http"
-	"os"
-	"os/exec"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// startHTTPModeServer launches the server binary in HTTP mode on a random free port.
-// It polls /healthz until the server is ready and returns the base URL.
-// The server process is automatically terminated when the test ends.
-func startHTTPModeServer(t *testing.T) string {
-	t.Helper()
-
-	port, err := freePort()
-	require.NoError(t, err, "could not find a free port")
-
-	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
-
-	// In HTTP mode the config validation rejects NEO4J_URI, NEO4J_USERNAME, NEO4J_PASSWORD, and
-	// NEO4J_DATABASE — the URI, credentials, and database are supplied per-request via the
-	// X-Neo4j-MCP-URI header, Auth headers, and URL path respectively.
-	// Strip those keys so any locally-set env values don't cause a startup validation error.
-	cmd := exec.Command(server, // #nosec G204 -- server is a binary path built by the test harness, not user input
-		"--neo4j-transport-mode", "http",
-		"--neo4j-http-host", "127.0.0.1",
-		"--neo4j-http-port", fmt.Sprintf("%d", port),
-		"--neo4j-telemetry", "false",
-	)
-	cmd.Env = stripEnv(os.Environ(), "NEO4J_URI", "NEO4J_USERNAME", "NEO4J_PASSWORD", "NEO4J_DATABASE")
-
-	require.NoError(t, cmd.Start(), "failed to start HTTP server")
-
-	t.Cleanup(func() {
-		if cmd.Process != nil {
-			_ = cmd.Process.Kill()
-			_ = cmd.Wait()
-		}
-	})
-
-	waitForHealthz(t, baseURL+"/healthz")
-	return baseURL
-}
-
-// freePort returns an available TCP port on localhost.
-func freePort() (int, error) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return 0, err
-	}
-	defer ln.Close()
-	return ln.Addr().(*net.TCPAddr).Port, nil
-}
-
-// stripEnv returns a copy of env with entries matching any of the given keys removed.
-func stripEnv(env []string, keys ...string) []string {
-	filtered := make([]string, 0, len(env))
-	for _, e := range env {
-		skip := false
-		for _, key := range keys {
-			if strings.HasPrefix(e, key+"=") {
-				skip = true
-				break
-			}
-		}
-		if !skip {
-			filtered = append(filtered, e)
-		}
-	}
-	return filtered
-}
-
-// waitForHealthz polls /healthz until it returns HTTP 200 or the deadline expires.
-func waitForHealthz(t *testing.T, url string) {
-	t.Helper()
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		resp, err := http.Get(url) // #nosec G107
-		if err == nil {
-			resp.Body.Close()
-			if resp.StatusCode == http.StatusOK {
-				return
-			}
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	t.Fatalf("server at %s did not become ready within 10s", url)
-}
-
 // TestHealthzE2E verifies the /healthz and /mcp ping behaviour of a live HTTP-mode server.
+//
+// HTTP-mode helpers (server startup, port discovery, env stripping, healthz polling)
+// live in http_server_helpers_test.go so other e2e tests can reuse them without
+// importing from this file.
 func TestHealthzE2E(t *testing.T) {
 	t.Parallel()
 

--- a/test/e2e/helpers/helpers.go
+++ b/test/e2e/helpers/helpers.go
@@ -41,7 +41,7 @@ type E2ETestContext struct {
 }
 
 // NewE2ETestContext creates a new E2E test context with automatic cleanup
-func NewE2ETestContext(t *testing.T, driver *neo4j.DriverWithContext) *E2ETestContext {
+func NewE2ETestContext(t *testing.T, driver *neo4j.Driver) *E2ETestContext {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)

--- a/test/e2e/http_server_helpers_test.go
+++ b/test/e2e/http_server_helpers_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+//go:build e2e
+
+// Shared helpers for spinning up the MCP server in HTTP transport mode against a
+// random local port. Kept in their own file so any e2e test that needs an HTTP
+// server can use them without depending on (or importing from) another test
+// file.
+package e2e
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// startHTTPModeServer launches the server binary in HTTP mode on a random free port.
+// It polls /healthz until the server is ready and returns the base URL.
+// The server process is automatically terminated when the test ends.
+func startHTTPModeServer(t *testing.T) string {
+	t.Helper()
+
+	port, err := freePort()
+	require.NoError(t, err, "could not find a free port")
+
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	// In HTTP mode the config validation rejects NEO4J_URI, NEO4J_USERNAME, NEO4J_PASSWORD, and
+	// NEO4J_DATABASE — the URI, credentials, and database are supplied per-request via the
+	// X-Neo4j-MCP-URI header, Auth headers, and URL path respectively.
+	// Strip those keys so any locally-set env values don't cause a startup validation error.
+	cmd := exec.Command(server, // #nosec G204 -- server is a binary path built by the test harness, not user input
+		"--neo4j-transport-mode", "http",
+		"--neo4j-http-host", "127.0.0.1",
+		"--neo4j-http-port", fmt.Sprintf("%d", port),
+		"--neo4j-telemetry", "false",
+	)
+	cmd.Env = stripEnv(os.Environ(), "NEO4J_URI", "NEO4J_USERNAME", "NEO4J_PASSWORD", "NEO4J_DATABASE")
+
+	require.NoError(t, cmd.Start(), "failed to start HTTP server")
+
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	})
+
+	waitForHealthz(t, baseURL+"/healthz")
+	return baseURL
+}
+
+// freePort returns an available TCP port on localhost.
+func freePort() (int, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer ln.Close()
+	return ln.Addr().(*net.TCPAddr).Port, nil
+}
+
+// stripEnv returns a copy of env with entries matching any of the given keys removed.
+func stripEnv(env []string, keys ...string) []string {
+	filtered := make([]string, 0, len(env))
+	for _, e := range env {
+		skip := false
+		for _, key := range keys {
+			if strings.HasPrefix(e, key+"=") {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
+}
+
+// waitForHealthz polls /healthz until it returns HTTP 200 or the deadline expires.
+func waitForHealthz(t *testing.T, url string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url) // #nosec G107
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("server at %s did not become ready within 10s", url)
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var dbs = dbservice.NewDBService()
-var server string = ""
+var server string
 
 func TestMain(m *testing.M) {
 	ctx := context.Background()

--- a/test/e2e/multi_tenant_initialize_test.go
+++ b/test/e2e/multi_tenant_initialize_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/neo4j/mcp/test/e2e/helpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMultiTenantHTTPInitializeIsolation verifies that, in HTTP transport mode,
+// two consecutive initialize requests from different "tenants" do not affect each
+// other. In particular, a first initialize that fails because the caller supplied
+// wrong credentials must not leave the server in a state that prevents a second,
+// well-formed initialize from succeeding.
+//
+// HTTP mode is multi-tenant by design: each request carries its own bolt URI
+// (via the X-Neo4j-MCP-URI header) and Neo4j credentials (via Basic Auth), and
+// the server runs verifyRequirements against those per-request credentials on
+// every initialize. Tenant A's failure must therefore be fully isolated from
+// tenant B's request.
+func TestMultiTenantHTTPInitializeIsolation(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startHTTPModeServer(t)
+	// The Neo4j test instance is reachable at the "neo4j" database. The path is
+	// validated by pathValidationMiddleware which only accepts /db/{name}/mcp.
+	mcpURL := baseURL + "/db/neo4j/mcp"
+
+	cfg := dbs.GetDriverConf()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Tenant A — valid URI header but wrong password. The auth middleware
+	// happily forwards the credentials, neo4jDriverMiddleware builds a per-request
+	// driver, and the initialize hook then runs verifyRequirements which fails
+	// because Neo4j rejects the password. The initialize call must propagate
+	// that failure back to the client.
+	wrongClient := newMultiTenantHTTPClient(t, mcpURL, cfg.Username, "definitely-not-the-password", cfg.URI)
+	defer wrongClient.Close()
+
+	require.NoError(t, wrongClient.Start(ctx), "wrong-tenant client failed to start")
+	_, err := wrongClient.Initialize(ctx, helpers.BuildInitializeRequest())
+	require.Error(t, err, "expected initialize with wrong credentials to fail")
+
+	// Tenant B — same server, correct credentials. If the server correctly
+	// isolates per-request state, this initialize must succeed even though the
+	// previous one (from a different tenant) failed.
+	rightClient := newMultiTenantHTTPClient(t, mcpURL, cfg.Username, cfg.Password, cfg.URI)
+	defer rightClient.Close()
+
+	require.NoError(t, rightClient.Start(ctx), "right-tenant client failed to start")
+	initResp, err := rightClient.Initialize(ctx, helpers.BuildInitializeRequest())
+	require.NoError(t, err, "expected initialize with right credentials to succeed after wrong tenant's failure")
+
+	assert.Equal(t, "neo4j-mcp", initResp.ServerInfo.Name)
+	assert.NotNil(t, initResp.Capabilities, "server must advertise capabilities after a successful initialize")
+	assert.NotNil(t, initResp.Capabilities.Tools, "server must advertise tools after a successful initialize")
+}
+
+// newMultiTenantHTTPClient builds an MCP streamable-HTTP client preconfigured with
+// per-tenant Basic Auth credentials and the Neo4j bolt URI header expected by the
+// server's multi-tenant HTTP mode. Each tenant gets its own client with its own
+// header set so credentials never bleed between requests.
+func newMultiTenantHTTPClient(t *testing.T, mcpURL, user, pass, boltURI string) *client.Client {
+	t.Helper()
+
+	authValue := "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+pass))
+
+	httpTransport, err := transport.NewStreamableHTTP(mcpURL,
+		transport.WithHTTPTimeout(15*time.Second),
+		transport.WithHTTPHeaders(map[string]string{
+			"Authorization":   authValue,
+			"X-Neo4j-MCP-URI": boltURI,
+		}),
+	)
+	require.NoError(t, err, "failed to build streamable HTTP transport")
+
+	return client.NewClient(httpTransport)
+}

--- a/test/integration/server_test.go
+++ b/test/integration/server_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/neo4j/mcp/internal/config"
 	"github.com/neo4j/mcp/internal/database"
 	"github.com/neo4j/mcp/internal/server"
@@ -89,7 +91,7 @@ func TestServerLifecycle(t *testing.T) {
 				t.Fatal("the NewNeo4jMCPServer() returned nil")
 			}
 
-			ctx, cancel := context.WithTimeout(context.Background(), 7*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
 			var wg sync.WaitGroup
@@ -104,13 +106,21 @@ func TestServerLifecycle(t *testing.T) {
 			for {
 				select {
 				case <-ctx.Done():
+					client, err := client.NewInProcessClient(s.MCPServer)
+					if err != nil {
+						t.Fatalf("error during client initilization: %s", err.Error())
+					}
+					_, err = client.Initialize(context.Background(), mcp.InitializeRequest{})
+					if startErr != nil {
+						t.Fatal("error while starting the MCP Server")
+					}
 					if tc.expectError {
-						if startErr == nil {
+						if err == nil {
 							t.Fatal("expected an error but got nil")
 						}
 					} else {
-						if startErr != nil {
-							t.Fatalf("Start returned an unexpected error: %s", startErr.Error())
+						if err != nil {
+							t.Fatalf("start returned an unexpected error: %s", startErr.Error())
 						}
 					}
 					return
@@ -122,7 +132,7 @@ func TestServerLifecycle(t *testing.T) {
 	}
 
 	t.Run("server stop should return no errors", func(t *testing.T) {
-		driver, err := neo4j.NewDriverWithContext(testCFG.URI, neo4j.BasicAuth(testCFG.Username, testCFG.Password, ""))
+		driver, err := neo4j.NewDriver(testCFG.URI, neo4j.BasicAuth(testCFG.Username, testCFG.Password, ""))
 		if err != nil {
 			t.Fatalf("failed to create Neo4j driver: %s", err.Error())
 		}

--- a/test/integration/server_test.go
+++ b/test/integration/server_test.go
@@ -120,7 +120,7 @@ func TestServerLifecycle(t *testing.T) {
 						}
 					} else {
 						if err != nil {
-							t.Fatalf("start returned an unexpected error: %s", startErr.Error())
+							t.Fatalf("start returned an unexpected error: %s", err.Error())
 						}
 					}
 					return


### PR DESCRIPTION
Moves Neo4j connectivity and plugin checks from server startup to the MCP Initialize hook, so HTTP multi-tenant mode can validate each environments independently. Removes shared server state (gdsInstalled, one-shot verification flags) that could leak failures across tenants.

Breaking: list-gds-procedures is always registered and appears in list/tools; runtime GDS auto-detection is removed. Initialize now returns clear errors for connectivity, APOC, or misconfiguration instead of failing silently at startup.