### PR TITLE
Support filtering of tools returned in tools/list response

### DIFF
--- a/.changes/unreleased/Minor-20260528-110236.yaml
+++ b/.changes/unreleased/Minor-20260528-110236.yaml
@@ -1,0 +1,6 @@
+kind: Minor
+body: |
+  The server now supports selective tool filtering through the "NEO4J_MCP_TOOLS" environment variable or the "--neo4j-tools" CLI argument.
+  These values are used to filter the tools returned in the "tools/list" MCP response. If not specified, all tools will be enabled.
+  You can pass multiple tools at once as a comma-separated list. Example: "--neo4j-tools 'get-schema,read-cypher'".
+time: 2026-05-28T11:02:36.109105+01:00

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -26,7 +26,7 @@ tasks:
   run:
     dotenv: [".env.task"]
     cmds:
-      - go run ./cmd/neo4j-mcp
+      - go run ./cmd/neo4j-mcp {{.CLI_ARGS}}
   run:compiled:
     dotenv: [".env.task"]
     cmds:

--- a/cmd/neo4j-mcp/main.go
+++ b/cmd/neo4j-mcp/main.go
@@ -39,6 +39,7 @@ func main() {
 		Password:                      cliArgs.Password,
 		Database:                      cliArgs.Database,
 		ReadOnly:                      cliArgs.ReadOnly,
+		Tools:                         cliArgs.Tools,
 		Telemetry:                     cliArgs.Telemetry,
 		TransportMode:                 cliArgs.TransportMode,
 		Port:                          cliArgs.HTTPPort,

--- a/internal/cli/args.go
+++ b/internal/cli/args.go
@@ -128,8 +128,10 @@ func ParseConfigFlags() *Args {
 	neo4jDatabase := flag.String("neo4j-database", "", "Neo4j database name (overrides NEO4J_DATABASE env var)")
 	neo4jReadOnly := flag.String("neo4j-read-only", "", "Enable read-only mode: true or false (overrides NEO4J_READ_ONLY env var)")
 	var neo4jTools *string
-	// allows explicit empty string arguments to be differentiated from unset arguments, which isn't possible with flag.String
 	flag.Func("neo4j-tools", "Define tools available by filtering tools returned in tools/list response", func(s string) error {
+		if s == "" {
+			return fmt.Errorf("cannot be empty; omit the flag to use all tools, or provide a comma-separated list of tools")
+		}
 		neo4jTools = &s
 		return nil
 	})

--- a/internal/cli/args.go
+++ b/internal/cli/args.go
@@ -27,6 +27,7 @@ Options:
   --neo4j-password <PASSWORD>         Database password (overrides environment variable NEO4J_PASSWORD)
   --neo4j-database <DATABASE>         Database name (overrides environment variable NEO4J_DATABASE)
   --neo4j-read-only <BOOLEAN>         Enable read-only mode: true or false (overrides environment variable NEO4J_READ_ONLY)
+  --neo4j-tools <TOOLS>               Define tools available by filtering tools returned in tools/list response
   --neo4j-telemetry <BOOLEAN>         Enable telemetry: true or false (overrides environment variable NEO4J_TELEMETRY)
   --neo4j-schema-sample-size <INT>    Number of nodes to sample for schema inference (overrides environment variable NEO4J_SCHEMA_SAMPLE_SIZE)
   --neo4j-transport-mode <MODE>       MCP Transport mode (e.g., 'stdio', 'http') (overrides environment variable NEO4J_TRANSPORT_MODE & NEO4J_MCP_TRANSPORT(deprecated))
@@ -51,6 +52,7 @@ Optional Environment Variables:
   NEO4J_READ_ONLY Enable read-only mode (default: false)
   NEO4J_SCHEMA_SAMPLE_SIZE Number of nodes to sample for schema inference (default: 100)
   NEO4J_TRANSPORT_MODE MCP Transport mode (e.g., 'stdio', 'http') (default: stdio)
+  NEO4J_MCP_TOOLS Define tools available by filtering tools returned in tools/list response (default: all tools enabled)
   NEO4J_MCP_TRANSPORT MCP Transport mode (e.g., 'stdio', 'http') (default: stdio)
   NEO4J_MCP_HTTP_PORT HTTP server port (default: 443 with TLS, 80 without TLS)
   NEO4J_MCP_HTTP_HOST HTTP server host (default: 127.0.0.1)
@@ -79,6 +81,7 @@ type Args struct {
 	Password                          string // #nosec G117 -- Password is only used during startup to create auth token, not logged or exposed
 	Database                          string
 	ReadOnly                          string
+	Tools                             *string // allows explicit empty string arguments to be differentiated from unset arguments
 	Telemetry                         string
 	SchemaSampleSize                  string
 	TransportMode                     string
@@ -101,6 +104,7 @@ var argsSlice = []string{
 	"--neo4j-password",
 	"--neo4j-database",
 	"--neo4j-read-only",
+	"--neo4j-tools",
 	"--neo4j-telemetry",
 	"--neo4j-schema-sample-size",
 	"--neo4j-transport-mode",
@@ -123,6 +127,12 @@ func ParseConfigFlags() *Args {
 	neo4jPassword := flag.String("neo4j-password", "", "Neo4j password (overrides NEO4J_PASSWORD env var)")
 	neo4jDatabase := flag.String("neo4j-database", "", "Neo4j database name (overrides NEO4J_DATABASE env var)")
 	neo4jReadOnly := flag.String("neo4j-read-only", "", "Enable read-only mode: true or false (overrides NEO4J_READ_ONLY env var)")
+	var neo4jTools *string
+	// allows explicit empty string arguments to be differentiated from unset arguments, which isn't possible with flag.String
+	flag.Func("neo4j-tools", "Define tools available by filtering tools returned in tools/list response", func(s string) error {
+		neo4jTools = &s
+		return nil
+	})
 	neo4jTelemetry := flag.String("neo4j-telemetry", "", "Enable telemetry: true or false (overrides NEO4J_TELEMETRY env var)")
 	neo4jSchemaSampleSize := flag.String("neo4j-schema-sample-size", "", "Number of nodes to sample for schema inference (overrides NEO4J_SCHEMA_SAMPLE_SIZE env var)")
 	neo4jTransportMode := flag.String("neo4j-transport-mode", "", "MCP Transport mode (e.g., 'stdio', 'http') (overrides NEO4J_TRANSPORT_MODE env var)")
@@ -144,6 +154,7 @@ func ParseConfigFlags() *Args {
 		Password:                          *neo4jPassword,
 		Database:                          *neo4jDatabase,
 		ReadOnly:                          *neo4jReadOnly,
+		Tools:                             neo4jTools,
 		Telemetry:                         *neo4jTelemetry,
 		SchemaSampleSize:                  *neo4jSchemaSampleSize,
 		TransportMode:                     *neo4jTransportMode,

--- a/internal/cli/args_test.go
+++ b/internal/cli/args_test.go
@@ -138,6 +138,24 @@ func TestHandleArgs(t *testing.T) {
 			expectedExitCode: -1, // Should not exit, flag is allowed
 		},
 		{
+			name:             "neo4j-tools flag with one tool name",
+			args:             []string{testProgramName, "--neo4j-tools", "get-schema"},
+			version:          testVersion,
+			expectedExitCode: -1, // Should not exit, flag is allowed
+		},
+		{
+			name:             "neo4j-tools flag with trailing comma after tool name",
+			args:             []string{testProgramName, "--neo4j-tools", "get-schema,"},
+			version:          testVersion,
+			expectedExitCode: -1, // Should not exit, flag is allowed
+		},
+		{
+			name:             "neo4j-tools flag with two tool names",
+			args:             []string{testProgramName, "--neo4j-tools", "get-schema,read-cypher"},
+			version:          testVersion,
+			expectedExitCode: -1, // Should not exit, flag is allowed
+		},
+		{
 			name:             "multiple configuration flags",
 			args:             []string{testProgramName, "--neo4j-uri", "bolt://localhost:7687", "--neo4j-username", "user"},
 			version:          testVersion,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -189,8 +189,7 @@ func LoadConfig(cliOverrides *CLIOverrides) (*Config, error) {
 		AllowUnauthenticatedToolsList: ParseBool(GetEnv("NEO4J_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST"), false),
 	}
 
-	// LookupEnv lets us distinguish between an explicit empty value, and an unset environment variable, which is needed for the MCP tools list
-	if toolsEnv, ok := os.LookupEnv("NEO4J_MCP_TOOLS"); ok {
+	if toolsEnv := GetEnv("NEO4J_MCP_TOOLS"); toolsEnv != "" {
 		cfg.Tools = ParseCommaSeparatedString(toolsEnv)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -189,7 +189,10 @@ func LoadConfig(cliOverrides *CLIOverrides) (*Config, error) {
 		AllowUnauthenticatedToolsList: ParseBool(GetEnv("NEO4J_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST"), false),
 	}
 
-	if toolsEnv := GetEnv("NEO4J_MCP_TOOLS"); toolsEnv != "" {
+	if toolsEnv, ok := os.LookupEnv("NEO4J_MCP_TOOLS"); ok {
+		if toolsEnv == "" {
+			return nil, fmt.Errorf("invalid tools configuration: NEO4J_MCP_TOOLS is set but empty; provide a comma-separated list of tools or unset the variable")
+		}
 		cfg.Tools = ParseCommaSeparatedString(toolsEnv)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,9 @@ const (
 // ValidTransportModes defines the allowed transport mode values
 var ValidTransportModes = []TransportMode{TransportModeStdio, TransportModeHTTP}
 
+// AvailableTools defines the available MCP tools
+var AvailableTools = []string{"read-cypher", "write-cypher", "list-gds-procedures", "get-schema"}
+
 // Config holds the application configuration
 type Config struct {
 	URI                           string
@@ -35,6 +38,7 @@ type Config struct {
 	Password                      string // #nosec G117
 	Database                      string
 	ReadOnly                      bool // If true, disables write tools
+	Tools                         []string
 	Telemetry                     bool // If false, disables telemetry
 	LogLevel                      string
 	LogFormat                     string
@@ -110,6 +114,12 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	for _, toolName := range c.Tools {
+		if !slices.Contains(AvailableTools, toolName) {
+			return fmt.Errorf("tool %q is invalid. Available tools are: %s", toolName, strings.Join(AvailableTools, ", "))
+		}
+	}
+
 	return nil
 }
 
@@ -120,6 +130,7 @@ type CLIOverrides struct {
 	Password                      string // #nosec G117
 	Database                      string
 	ReadOnly                      string
+	Tools                         *string
 	Telemetry                     string
 	TransportMode                 string
 	Port                          string
@@ -178,6 +189,11 @@ func LoadConfig(cliOverrides *CLIOverrides) (*Config, error) {
 		AllowUnauthenticatedToolsList: ParseBool(GetEnv("NEO4J_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST"), false),
 	}
 
+	// LookupEnv lets us distinguish between an explicit empty value, and an unset environment variable, which is needed for the MCP tools list
+	if toolsEnv, ok := os.LookupEnv("NEO4J_MCP_TOOLS"); ok {
+		cfg.Tools = ParseCommaSeparatedString(toolsEnv)
+	}
+
 	// Apply CLI overrides if provided
 	if cliOverrides != nil {
 		if cliOverrides.URI != "" {
@@ -194,6 +210,9 @@ func LoadConfig(cliOverrides *CLIOverrides) (*Config, error) {
 		}
 		if cliOverrides.ReadOnly != "" {
 			cfg.ReadOnly = ParseBool(cliOverrides.ReadOnly, false)
+		}
+		if cliOverrides.Tools != nil {
+			cfg.Tools = ParseCommaSeparatedString(*cliOverrides.Tools)
 		}
 		if cliOverrides.Telemetry != "" {
 			cfg.Telemetry = ParseBool(cliOverrides.Telemetry, true)
@@ -238,6 +257,12 @@ func LoadConfig(cliOverrides *CLIOverrides) (*Config, error) {
 		} else {
 			cfg.HTTPPort = "80"
 		}
+	}
+
+	// If tools haven't been set at this point, they have neither been provided nor explicitly unset
+	// Default to all available tools
+	if cfg.Tools == nil {
+		cfg.Tools = AvailableTools
 	}
 
 	// Normalize and validate
@@ -307,4 +332,18 @@ func ParseInt32(value string, defaultValue int32) int32 {
 		return defaultValue
 	}
 	return int32(parsed)
+}
+
+// ParseCommaSeparatedString parses a comma-separated string into a slice of strings.
+// Ensures that whitespace, trailing and leading commas are ignored.
+func ParseCommaSeparatedString(value string) []string {
+	parts := strings.Split(value, ",")
+	n := 0
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			parts[n] = p
+			n++
+		}
+	}
+	return parts[:n]
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -968,9 +968,9 @@ func TestLoadConfig_Neo4jMCPToolsEnvVar(t *testing.T) {
 			expectedTools: []string{"read-cypher", "write-cypher"},
 		},
 		{
-			name:          "When tool list is provided as empty string, it should use all tools",
-			toolsEnv:      newStringPtr(""),
-			expectedTools: AvailableTools,
+			name:     "When tool list is provided as empty string, should raise error",
+			toolsEnv: newStringPtr(""),
+			wantErr:  "NEO4J_MCP_TOOLS is set but empty",
 		},
 		{
 			name:          "When tool list is unset, all tools should be enabled",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -117,6 +117,19 @@ func TestConfig_Validate(t *testing.T) {
 			wantErr: true,
 			errMsg:  "Neo4j username and password should not be set for HTTP transport mode; credentials are provided per-request via Auth headers",
 		},
+		{
+			name: "invalid tool should raise error",
+			cfg: &Config{
+				Telemetry: true,
+				Username:  "neo4j",
+				Password:  "password",
+				URI:       "bolt://localhost:7687",
+				Tools:     []string{"invalid-tool"},
+				Database:  "neo4j",
+			},
+			wantErr: true,
+			errMsg:  `tool "invalid-tool" is invalid. Available tools are: read-cypher, write-cypher, list-gds-procedures, get-schema`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -911,4 +924,166 @@ func TestLoadConfig_HTTPModeDatabase(t *testing.T) {
 			assert.Equal(t, tt.wantDatabase, cfg.Database)
 		})
 	}
+}
+
+func TestLoadConfig_Neo4jMCPToolsEnvVar(t *testing.T) {
+	tests := []struct {
+		name          string
+		toolsEnv      *string
+		expectedTools []string
+		wantErr       string
+	}{
+		{
+			name:          "When tool list is not provided, default tool list should be used",
+			expectedTools: AvailableTools,
+		},
+		{
+			name:          "When tool list is provided, it should replace default tool list",
+			toolsEnv:      newStringPtr("read-cypher,get-schema"),
+			expectedTools: []string{"read-cypher", "get-schema"},
+		},
+		{
+			name:     "When tool name is invalid, should raise error",
+			toolsEnv: newStringPtr("invalid-tool"),
+			wantErr:  `tool "invalid-tool" is invalid. Available tools are: read-cypher, write-cypher, list-gds-procedures, get-schema`,
+		},
+		{
+			name:          "When tool name has surrounding whitespace, it should be trimmed",
+			toolsEnv:      newStringPtr("write-cypher ,read-cypher"),
+			expectedTools: []string{"write-cypher", "read-cypher"},
+		},
+		{
+			name:          "When tool list contains only commas, no tools should be selected",
+			toolsEnv:      newStringPtr(",,"),
+			expectedTools: []string{},
+		},
+		{
+			name:          "When tool list contains a leading comma, it should be ignored",
+			toolsEnv:      newStringPtr(",read-cypher,write-cypher"),
+			expectedTools: []string{"read-cypher", "write-cypher"},
+		},
+		{
+			name:          "When tool list contains a trailing comma, it should be ignored",
+			toolsEnv:      newStringPtr("read-cypher,write-cypher,"),
+			expectedTools: []string{"read-cypher", "write-cypher"},
+		},
+		{
+			name:          "When tool list is provided as empty string, it should disable all tools",
+			toolsEnv:      newStringPtr(""),
+			expectedTools: []string{},
+		},
+		{
+			name:          "When tool list is unset, all tools should be enabled",
+			toolsEnv:      nil,
+			expectedTools: AvailableTools,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("NEO4J_TRANSPORT_MODE", "stdio")
+			t.Setenv("NEO4J_URI", "bolt://localhost:7687")
+			t.Setenv("NEO4J_USERNAME", "neo4j")
+			t.Setenv("NEO4J_PASSWORD", "password")
+			t.Setenv("NEO4J_DATABASE", "neo4j")
+			if tt.toolsEnv != nil {
+				t.Setenv("NEO4J_MCP_TOOLS", *tt.toolsEnv)
+			}
+
+			cfg, err := LoadConfig(&CLIOverrides{})
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedTools, cfg.Tools)
+		})
+	}
+}
+
+func TestLoadConfig_Neo4jMCPToolsCLIOverride(t *testing.T) {
+	tests := []struct {
+		name          string
+		toolsEnv      string
+		cliTools      *string
+		expectedTools []string
+		wantErr       string
+	}{
+		{
+			name:          "When tool list is provided, it should replace default tool list",
+			cliTools:      newStringPtr("write-cypher"),
+			expectedTools: []string{"write-cypher"},
+		},
+		{
+			name:          "When tool list is provided in both CLI and env var, CLI should take precedence",
+			toolsEnv:      "read-cypher,get-schema",
+			cliTools:      newStringPtr("write-cypher"),
+			expectedTools: []string{"write-cypher"},
+		},
+		{
+			name:     "When tool name is invalid, should raise error",
+			cliTools: newStringPtr("invalid-tool"),
+			wantErr:  `tool "invalid-tool" is invalid. Available tools are: read-cypher, write-cypher, list-gds-procedures, get-schema`,
+		},
+		{
+			name:          "When tool name has surrounding whitespace, it should be trimmed",
+			cliTools:      newStringPtr("write-cypher ,read-cypher"),
+			expectedTools: []string{"write-cypher", "read-cypher"},
+		},
+		{
+			name:          "When tool list contains only commas, no tools should be selected",
+			cliTools:      newStringPtr(",,"),
+			expectedTools: []string{},
+		},
+		{
+			name:          "When tool list contains a leading comma, it should be ignored",
+			cliTools:      newStringPtr(",read-cypher,write-cypher"),
+			expectedTools: []string{"read-cypher", "write-cypher"},
+		},
+		{
+			name:          "When tool list contains a trailing comma, it should be ignored",
+			cliTools:      newStringPtr("read-cypher,write-cypher,"),
+			expectedTools: []string{"read-cypher", "write-cypher"},
+		},
+		{
+			name:          "When tool list is provided as empty string, it should disable all tools",
+			cliTools:      newStringPtr(""),
+			expectedTools: []string{},
+		},
+		{
+			name:          "When tool list is unset, all tools should be enabled",
+			cliTools:      nil,
+			expectedTools: AvailableTools,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("NEO4J_TRANSPORT_MODE", "stdio")
+			t.Setenv("NEO4J_URI", "bolt://localhost:7687")
+			t.Setenv("NEO4J_USERNAME", "neo4j")
+			t.Setenv("NEO4J_PASSWORD", "password")
+			t.Setenv("NEO4J_DATABASE", "neo4j")
+			if tt.toolsEnv != "" {
+				t.Setenv("NEO4J_MCP_TOOLS", tt.toolsEnv)
+			}
+
+			cfg, err := LoadConfig(&CLIOverrides{
+				Tools: tt.cliTools,
+			})
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedTools, cfg.Tools)
+		})
+	}
+}
+
+// newStringPtr returns a new pointer to a string
+func newStringPtr(s string) *string {
+	return &s
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -968,9 +968,9 @@ func TestLoadConfig_Neo4jMCPToolsEnvVar(t *testing.T) {
 			expectedTools: []string{"read-cypher", "write-cypher"},
 		},
 		{
-			name:          "When tool list is provided as empty string, it should disable all tools",
+			name:          "When tool list is provided as empty string, it should use all tools",
 			toolsEnv:      newStringPtr(""),
-			expectedTools: []string{},
+			expectedTools: AvailableTools,
 		},
 		{
 			name:          "When tool list is unset, all tools should be enabled",
@@ -1045,11 +1045,6 @@ func TestLoadConfig_Neo4jMCPToolsCLIOverride(t *testing.T) {
 			name:          "When tool list contains a trailing comma, it should be ignored",
 			cliTools:      newStringPtr("read-cypher,write-cypher,"),
 			expectedTools: []string{"read-cypher", "write-cypher"},
-		},
-		{
-			name:          "When tool list is provided as empty string, it should disable all tools",
-			cliTools:      newStringPtr(""),
-			expectedTools: []string{},
 		},
 		{
 			name:          "When tool list is unset, all tools should be enabled",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -82,7 +82,6 @@ func NewNeo4jMCPServer(version string, cfg *config.Config, dbService database.Se
 
 // Start initializes and starts the MCP server
 func (s *Neo4jMCPServer) Start() error {
-	slog.Info("Registering server tools")
 	s.registerTools()
 	s.emitServerStartupEvent()
 	switch s.config.TransportMode {

--- a/internal/server/server_http_lifecycle_test.go
+++ b/internal/server/server_http_lifecycle_test.go
@@ -65,6 +65,7 @@ func TestNeo4jMCPServerHTTPMode(t *testing.T) {
 		URI:           "bolt://test-host:7687",
 		Database:      "neo4j",
 		TransportMode: config.TransportModeHTTP,
+		Tools:         config.AvailableTools,
 		HTTPHost:      "127.0.0.1",
 		HTTPPort:      strconv.Itoa(port),
 	}

--- a/internal/server/tool_register_test.go
+++ b/internal/server/tool_register_test.go
@@ -12,6 +12,7 @@ import (
 	db "github.com/neo4j/mcp/internal/database/mocks"
 	"github.com/neo4j/mcp/internal/server"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -132,7 +133,7 @@ func TestToolRegister(t *testing.T) {
 		// Start server and register tools
 		err := s.Start()
 		if err != nil {
-			t.Fatalf("Start() failed: %v", err)
+			require.NoError(t, err)
 		}
 
 		var toolNames []string
@@ -159,7 +160,7 @@ func TestToolRegister(t *testing.T) {
 		// Start server and register tools
 		err := s.Start()
 		if err != nil {
-			t.Fatalf("Start() failed: %v", err)
+			require.NoError(t, err)
 		}
 
 		assert.Empty(t, s.MCPServer.ListTools())

--- a/internal/server/tool_register_test.go
+++ b/internal/server/tool_register_test.go
@@ -4,12 +4,14 @@
 package server_test
 
 import (
+	"sort"
 	"testing"
 
 	analytics "github.com/neo4j/mcp/internal/analytics/mocks"
 	"github.com/neo4j/mcp/internal/config"
 	db "github.com/neo4j/mcp/internal/database/mocks"
 	"github.com/neo4j/mcp/internal/server"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
 
@@ -34,6 +36,7 @@ func TestToolRegister(t *testing.T) {
 			Username:      "neo4j",
 			Password:      "password",
 			Database:      "neo4j",
+			Tools:         config.AvailableTools,
 			TransportMode: config.TransportModeStdio,
 		}
 		s := server.NewNeo4jMCPServer("test-version", cfg, mockDB, aService)
@@ -62,6 +65,7 @@ func TestToolRegister(t *testing.T) {
 			Password:      "password",
 			Database:      "neo4j",
 			ReadOnly:      true,
+			Tools:         config.AvailableTools,
 			TransportMode: config.TransportModeStdio,
 		}
 		s := server.NewNeo4jMCPServer("test-version", cfg, mockDB, aService)
@@ -89,6 +93,7 @@ func TestToolRegister(t *testing.T) {
 			Password:      "password",
 			Database:      "neo4j",
 			ReadOnly:      false,
+			Tools:         config.AvailableTools,
 			TransportMode: config.TransportModeStdio,
 		}
 		s := server.NewNeo4jMCPServer("test-version", cfg, mockDB, aService)
@@ -109,5 +114,54 @@ func TestToolRegister(t *testing.T) {
 			t.Errorf("Expected %d tools, but test configuration shows %d", expectedTotalToolsCount, registeredTools)
 		}
 	})
+	t.Run("should only register tools that are specified in config", func(t *testing.T) {
+		cfg := &config.Config{
+			URI:           "bolt://test-host:7687",
+			Username:      "neo4j",
+			Password:      "password",
+			Database:      "neo4j",
+			ReadOnly:      false,
+			Tools:         []string{"read-cypher", "get-schema"},
+			TransportMode: config.TransportModeStdio,
+		}
+		s := server.NewNeo4jMCPServer("test-version", cfg, mockDB, aService)
 
+		// Expected tools that should be registered
+		expectedTools := []string{"get-schema", "read-cypher"}
+
+		// Start server and register tools
+		err := s.Start()
+		if err != nil {
+			t.Fatalf("Start() failed: %v", err)
+		}
+
+		var toolNames []string
+		tools := s.MCPServer.ListTools()
+		for _, tool := range tools {
+			toolNames = append(toolNames, tool.Tool.Name)
+		}
+		sort.Strings(toolNames)
+
+		assert.Equal(t, expectedTools, toolNames)
+	})
+	t.Run("should not register write tools when readonly is enabled even if specified in tools config", func(t *testing.T) {
+		cfg := &config.Config{
+			URI:           "bolt://test-host:7687",
+			Username:      "neo4j",
+			Password:      "password",
+			Database:      "neo4j",
+			ReadOnly:      true,
+			Tools:         []string{"write-cypher"},
+			TransportMode: config.TransportModeStdio,
+		}
+		s := server.NewNeo4jMCPServer("test-version", cfg, mockDB, aService)
+
+		// Start server and register tools
+		err := s.Start()
+		if err != nil {
+			t.Fatalf("Start() failed: %v", err)
+		}
+
+		assert.Empty(t, s.MCPServer.ListTools())
+	})
 }

--- a/internal/server/tools_register.go
+++ b/internal/server/tools_register.go
@@ -18,7 +18,7 @@ import (
 // Tools are filtered according to the server configuration. For example, when the read-only
 // mode is enabled (e.g. via the Config.ReadOnly flag, which can be set by the NEO4J_READ_ONLY environment variable or --neo4j-read-only flag),
 // any tool that performs state mutation will be excluded.
-// Individual tools can also be selected via Config.Tools, which can be set by the NEO4J_TOOLS environment variable or --neo4j-tools flag, with Config.ReadOnly taking precedence.
+// Individual tools can also be selected via Config.Tools, which can be set by the NEO4J_MCP_TOOLS environment variable or --neo4j-tools flag, with Config.ReadOnly taking precedence.
 func (s *Neo4jMCPServer) registerTools() {
 	tools := s.getTools()
 	s.MCPServer.AddTools(tools...)

--- a/internal/server/tools_register.go
+++ b/internal/server/tools_register.go
@@ -4,6 +4,7 @@
 package server
 
 import (
+	"fmt"
 	"log/slog"
 	"slices"
 
@@ -42,10 +43,11 @@ func (s *Neo4jMCPServer) getTools() []server.ServerTool {
 	toolsDefs := s.getAllToolsDefs(deps)
 	serverTools := make([]server.ServerTool, 0, len(toolsDefs))
 	for _, toolDef := range toolsDefs {
-		if s.config.ReadOnly && !toolDef.readonly {
+		if !slices.Contains(s.config.Tools, toolDef.definition.Tool.Name) {
 			continue
 		}
-		if !slices.Contains(s.config.Tools, toolDef.definition.Tool.Name) {
+		if s.config.ReadOnly && !toolDef.readonly {
+			slog.Info(fmt.Sprintf("Ignoring tool '%s': not available in read-only mode", toolDef.definition.Tool.Name))
 			continue
 		}
 

--- a/internal/server/tools_register.go
+++ b/internal/server/tools_register.go
@@ -4,6 +4,9 @@
 package server
 
 import (
+	"log/slog"
+	"slices"
+
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/neo4j/mcp/internal/tools"
 	"github.com/neo4j/mcp/internal/tools/cypher"
@@ -12,13 +15,18 @@ import (
 
 // registerTools registers all enabled MCP tools and adds them to the provided MCP server.
 // Tools are filtered according to the server configuration. For example, when the read-only
-// mode is enabled (e.g. via the NEO4J_READ_ONLY environment variable or the Config.ReadOnly flag),
-// any tool that performs state mutation will be excluded; only tools annotated as read-only will be registered.
-// Note: this read-only filtering relies on the tool annotation "readonly" (ReadOnlyHint). If the annotation
-// is not defined or is set to false, the tool will be added (i.e., only tools with readonly=true are filtered in read-only mode).
+// mode is enabled (e.g. via the Config.ReadOnly flag, which can be set by the NEO4J_READ_ONLY environment variable or --neo4j-read-only flag),
+// any tool that performs state mutation will be excluded.
+// Individual tools can also be selected via Config.Tools, which can be set by the NEO4J_TOOLS environment variable or --neo4j-tools flag, with Config.ReadOnly taking precedence.
 func (s *Neo4jMCPServer) registerTools() {
 	tools := s.getTools()
 	s.MCPServer.AddTools(tools...)
+
+	toolNames := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		toolNames = append(toolNames, tool.Tool.Name)
+	}
+	slog.Info("Registered server tools", "count", len(toolNames), "tools", toolNames)
 }
 
 type ToolDefinition struct {
@@ -35,6 +43,9 @@ func (s *Neo4jMCPServer) getTools() []server.ServerTool {
 	serverTools := make([]server.ServerTool, 0, len(toolsDefs))
 	for _, toolDef := range toolsDefs {
 		if s.config.ReadOnly && !toolDef.readonly {
+			continue
+		}
+		if !slices.Contains(s.config.Tools, toolDef.definition.Tool.Name) {
 			continue
 		}
 


### PR DESCRIPTION
Adds support for configuring the MCP tools that are enabled on the server.
This is exposed via a new environment variable, `NEO4J_MCP_TOOLS`, and equivalent command line flag: `--neo4j-tools`.
Example: `neo4j-mcp --neo4j-tools 'read-cypher,write-cypher'`
When unset, the full list of tools will be enabled.
