### PR TITLE
fix: declare explicit JSON Schema for tool inputs

### DIFF
--- a/internal/tools/cypher/get_schema_spec.go
+++ b/internal/tools/cypher/get_schema_spec.go
@@ -4,22 +4,21 @@
 package cypher
 
 import (
+	"encoding/json"
+
 	"github.com/mark3labs/mcp-go/mcp"
 )
-type EmptyInput struct {
-    Properties map[string]interface{} `json:"properties"`
-}
 
 func GetSchemaSpec() mcp.Tool {
 	return mcp.NewTool("get-schema",
 		mcp.WithDescription(`
 		Retrieve the schema information from the Neo4j database, including node labels, relationship types, and property keys.
 		If the database contains no data, no schema information is returned.`),
+		rawInputSchema(json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`)),
 		mcp.WithTitleAnnotation("Get Neo4j Schema"),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithOpenWorldHintAnnotation(true),
-		mcp.WithInputSchema[EmptyInput](),
 	)
 }

--- a/internal/tools/cypher/read_cypher_spec.go
+++ b/internal/tools/cypher/read_cypher_spec.go
@@ -4,18 +4,35 @@
 package cypher
 
 import (
+	"encoding/json"
+
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
 type ReadCypherInput struct {
-	Query  string `json:"query" jsonschema:"The Cypher query to execute"`
-	Params Params `json:"params,omitempty" jsonschema:"Parameters to pass to the Cypher query"`
+	Query  string `json:"query"`
+	Params Params `json:"params,omitempty"`
 }
 
 func ReadCypherSpec() mcp.Tool {
 	return mcp.NewTool("read-cypher",
 		mcp.WithDescription("read-cypher can run only read-only Cypher statements. For write operations (CREATE, MERGE, DELETE, SET, etc...), schema/admin commands, or PROFILE queries, use write-cypher instead."),
-		mcp.WithInputSchema[ReadCypherInput](),
+		rawInputSchema(json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"query": {
+					"type": "string",
+					"description": "The Cypher query to execute"
+				},
+				"params": {
+					"type": "object",
+					"description": "Parameters to pass to the Cypher query",
+					"additionalProperties": true
+				}
+			},
+			"required": ["query"],
+			"additionalProperties": false
+		}`)),
 		mcp.WithTitleAnnotation("Read Cypher"),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),

--- a/internal/tools/cypher/schema_helpers.go
+++ b/internal/tools/cypher/schema_helpers.go
@@ -1,0 +1,21 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+package cypher
+
+import (
+	"encoding/json"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// rawInputSchema sets a raw JSON Schema as the tool's input schema, clearing
+// the default object schema that mcp.NewTool pre-populates. Without clearing
+// it, Tool.MarshalJSON fails with "provide either InputSchema or
+// RawInputSchema, not both".
+func rawInputSchema(schema json.RawMessage) mcp.ToolOption {
+	return func(t *mcp.Tool) {
+		t.InputSchema = mcp.ToolInputSchema{}
+		t.RawInputSchema = schema
+	}
+}

--- a/internal/tools/cypher/write_cypher_spec.go
+++ b/internal/tools/cypher/write_cypher_spec.go
@@ -4,18 +4,35 @@
 package cypher
 
 import (
+	"encoding/json"
+
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
 type WriteCypherInput struct {
-	Query  string `json:"query" jsonschema:"The Cypher query to execute"`
-	Params Params `json:"params,omitempty" jsonschema:"Parameters to pass to the Cypher query"`
+	Query  string `json:"query"`
+	Params Params `json:"params,omitempty"`
 }
 
 func WriteCypherSpec() mcp.Tool {
 	return mcp.NewTool("write-cypher",
 		mcp.WithDescription("write-cypher executes any arbitrary Cypher query, with write access, against the user-configured Neo4j database."),
-		mcp.WithInputSchema[WriteCypherInput](),
+		rawInputSchema(json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"query": {
+					"type": "string",
+					"description": "The Cypher query to execute"
+				},
+				"params": {
+					"type": "object",
+					"description": "Parameters to pass to the Cypher query",
+					"additionalProperties": true
+				}
+			},
+			"required": ["query"],
+			"additionalProperties": false
+		}`)),
 		mcp.WithTitleAnnotation("Write Cypher"),
 		mcp.WithReadOnlyHintAnnotation(false),
 		mcp.WithDestructiveHintAnnotation(true),

--- a/internal/tools/gds/list_gds_procedures_spec.go
+++ b/internal/tools/gds/list_gds_procedures_spec.go
@@ -3,11 +3,11 @@
 
 package gds
 
-import "github.com/mark3labs/mcp-go/mcp"
+import (
+	"encoding/json"
 
-type EmptyInput struct {
-	Properties map[string]interface{} `json:"properties"`
-}
+	"github.com/mark3labs/mcp-go/mcp"
+)
 
 func ListGDSProceduresSpec() mcp.Tool {
 	return mcp.NewTool("list-gds-procedures",
@@ -26,6 +26,6 @@ func ListGDSProceduresSpec() mcp.Tool {
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithOpenWorldHintAnnotation(true),
-		mcp.WithInputSchema[EmptyInput](),
+		rawInputSchema(json.RawMessage(`{"type":"object","properties":{},"additionalProperties":false}`)),
 	)
 }

--- a/internal/tools/gds/schema_helpers.go
+++ b/internal/tools/gds/schema_helpers.go
@@ -1,0 +1,21 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+package gds
+
+import (
+	"encoding/json"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// rawInputSchema sets a raw JSON Schema as the tool's input schema, clearing
+// the default object schema that mcp.NewTool pre-populates. Without clearing
+// it, Tool.MarshalJSON fails with "provide either InputSchema or
+// RawInputSchema, not both".
+func rawInputSchema(schema json.RawMessage) mcp.ToolOption {
+	return func(t *mcp.Tool) {
+		t.InputSchema = mcp.ToolInputSchema{}
+		t.RawInputSchema = schema
+	}
+}


### PR DESCRIPTION
## Summary

The `tools/list` response currently emits malformed JSON Schemas for four tools because the input-schema generation in `mcp-go` silently fails on the input types used:

- **`read-cypher` / `write-cypher`** use `mcp.WithInputSchema[ReadCypherInput]()`, where `ReadCypherInput.Params` is a custom map type (`Params`) with `UnmarshalJSON`. The `google/jsonschema-go` reflector can't derive a schema for it, so the emitted schema has `properties: {}` — no declared parameters at all, even though the tool requires `query`.
- **`get-schema` and `list-gds-procedures`** use `mcp.WithInputSchema[EmptyInput]()` with a struct that has a `Properties` field. The emitted schema requires a parameter literally named `"properties"`, which is nonsense for tools that take no arguments.

Forgiving clients (e.g. claude.ai) ignore these schemas; stricter MCP clients reject the tools outright. The tool descriptions themselves are correct — only the parameter declaration is wrong.

## What this PR does

Declares the input schemas explicitly with `WithRawInputSchema` via a small `rawInputSchema` helper:

```go
func rawInputSchema(schema json.RawMessage) mcp.ToolOption {
    return func(t *mcp.Tool) {
        t.InputSchema = mcp.ToolInputSchema{}
        t.RawInputSchema = schema
    }
}
```

The helper clears the default `InputSchema` that `mcp.NewTool` pre-populates (`Type: \"object\"`) — without that step, `Tool.MarshalJSON` errors with `\"provide either InputSchema or RawInputSchema, not both\"`.

`ReadCypherInput` / `WriteCypherInput` structs are retained because they're used for argument binding in the handlers and in tests; only the unused `jsonschema:` tag was removed. `EmptyInput` is dropped — it was only used as a (broken) schema placeholder.

## Before / after

`tools/list` for `read-cypher` (and `write-cypher`):

```diff
 \"inputSchema\": {
   \"type\": \"object\",
-  \"properties\": {},
-  \"required\": []
+  \"properties\": {
+    \"query\":  { \"type\": \"string\", \"description\": \"The Cypher query to execute\" },
+    \"params\": { \"type\": \"object\", \"description\": \"Parameters to pass to the Cypher query\", \"additionalProperties\": true }
+  },
+  \"required\": [\"query\"],
+  \"additionalProperties\": false
 }
```

`tools/list` for `get-schema` (and `list-gds-procedures`):

```diff
 \"inputSchema\": {
   \"type\": \"object\",
-  \"properties\": {
-    \"properties\": { \"type\": \"object\", \"additionalProperties\": true }
-  },
-  \"required\": [\"properties\"]
+  \"properties\": {},
+  \"additionalProperties\": false
 }
```

## Test plan

- [x] `go test ./internal/tools/cypher/... ./internal/tools/gds/...` passes locally (in the official builder Docker image)
- [x] Built the fixed image, ran the server in HTTP transport mode, and confirmed `tools/list` returns the schemas above
- [x] Confirmed `tools/call` for `read-cypher` with `{\"query\": \"MATCH (p) RETURN count(p)\"}` still works end-to-end against a real Neo4j Aura instance