### PR TITLE
Remove EmptyInput workaround now that mcp-go always emits properties

### DIFF
--- a/.changes/unreleased/Patch-20260610-150742.yaml
+++ b/.changes/unreleased/Patch-20260610-150742.yaml
@@ -1,0 +1,9 @@
+kind: Patch
+body: >-
+  Fixed the inputSchema advertised by `get-schema` and `list-gds-procedures` in
+  the `tools/list` response. Both tools previously emitted a schema that
+  required a spurious `properties` argument (an artefact of the `EmptyInput`
+  workaround introduced for OpenAI compatibility). mcp-go v0.46+ already
+  guarantees that a bare `NewTool` call emits `"properties": {}`, so the
+  workaround is no longer needed.
+time: 2026-06-10T15:07:42.108933+01:00

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,6 @@ github.com/lufia/plan9stats v0.0.0-20260216142805-b3301c5f2a88 h1:PTw+yKnXcOFCR6
 github.com/lufia/plan9stats v0.0.0-20260216142805-b3301c5f2a88/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/mark3labs/mcp-go v0.50.0 h1:kfxh8ejrBCABy5pez+rUYpsSLUKV2Yg38xBtrGRuo4U=
-github.com/mark3labs/mcp-go v0.50.0/go.mod h1:Zg9cB2HdwdMMVgY0xtTzq3KvYIOJQDsaut+jWjwDaQY=
 github.com/mark3labs/mcp-go v0.54.0 h1:PZhQvd+5xrT43cUoiaKn/hDcvLUhcLc1twSEKYPTcTA=
 github.com/mark3labs/mcp-go v0.54.0/go.mod h1:+8WclSK1ZUweCP3hvktSji8n8ABG/95QaEkeVE/Uwas=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
@@ -84,8 +82,6 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
-github.com/neo4j/neo4j-go-driver/v6 v6.0.0 h1:xVAi6YLOfzXUx+1Lc/F2dUhpbN76BfKleZbAlnDFRiA=
-github.com/neo4j/neo4j-go-driver/v6 v6.0.0/go.mod h1:hzSTfNfM31p1uRSzL1F/BAYOgaiTarE6OAQBajfsm+I=
 github.com/neo4j/neo4j-go-driver/v6 v6.1.0 h1:kx/h9lHV9XJEWTzAV0/23/bzvdl8qcq3rLhHN3Z118M=
 github.com/neo4j/neo4j-go-driver/v6 v6.1.0/go.mod h1:hzSTfNfM31p1uRSzL1F/BAYOgaiTarE6OAQBajfsm+I=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/internal/tools/cypher/get_schema_spec.go
+++ b/internal/tools/cypher/get_schema_spec.go
@@ -6,9 +6,6 @@ package cypher
 import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
-type EmptyInput struct {
-    Properties map[string]interface{} `json:"properties"`
-}
 
 func GetSchemaSpec() mcp.Tool {
 	return mcp.NewTool("get-schema",
@@ -20,6 +17,5 @@ func GetSchemaSpec() mcp.Tool {
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithOpenWorldHintAnnotation(true),
-		mcp.WithInputSchema[EmptyInput](),
 	)
 }

--- a/internal/tools/gds/list_gds_procedures_spec.go
+++ b/internal/tools/gds/list_gds_procedures_spec.go
@@ -5,10 +5,6 @@ package gds
 
 import "github.com/mark3labs/mcp-go/mcp"
 
-type EmptyInput struct {
-	Properties map[string]interface{} `json:"properties"`
-}
-
 func ListGDSProceduresSpec() mcp.Tool {
 	return mcp.NewTool("list-gds-procedures",
 		mcp.WithDescription(
@@ -26,6 +22,5 @@ func ListGDSProceduresSpec() mcp.Tool {
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithOpenWorldHintAnnotation(true),
-		mcp.WithInputSchema[EmptyInput](),
 	)
 }

--- a/test/e2e/server_initialization_test.go
+++ b/test/e2e/server_initialization_test.go
@@ -286,9 +286,7 @@ func TestServerInitializationE2E(t *testing.T) {
 					IdempotentHint:  mcp.ToBoolPtr(true),
 					OpenWorldHint:   mcp.ToBoolPtr(true),
 				},
-				properties: map[string]propertyExpectation{
-					"properties": {jsonSchemaType: "object", required: true},
-				},
+				properties: map[string]propertyExpectation{},
 			},
 			"list-gds-procedures": {
 				annotations: mcp.ToolAnnotation{
@@ -298,9 +296,7 @@ func TestServerInitializationE2E(t *testing.T) {
 					IdempotentHint:  mcp.ToBoolPtr(true),
 					OpenWorldHint:   mcp.ToBoolPtr(true),
 				},
-				properties: map[string]propertyExpectation{
-					"properties": {jsonSchemaType: "object", required: true},
-				},
+				properties: map[string]propertyExpectation{},
 			},
 		}
 


### PR DESCRIPTION
## Summary

- get-schema and list-gds-procedures previously emitted a broken inputSchema that required a arbitrary "properties" argument an artefact of the EmptyInput workaround introduced in #157 for OpenAI API compatibility.

- That workaround is no longer needed, guarantees that a bare NewTool call always emits "properties": {}, satisfying the OpenAI requirement without any workaround on our side.

- This PR removes `EmptyInput` and the `WithInputSchema[EmptyInput]()` calls from both tools, and updates the `server_initialization_test.go` expectations to match the clean no-argument schema.