### PR TITLE
feat: add vector-search tool with query-time in-database embeddings

### DIFF
--- a/.changes/unreleased/Minor-vector-search.yaml
+++ b/.changes/unreleased/Minor-vector-search.yaml
@@ -1,0 +1,3 @@
+kind: Minor
+body: 'Add `vector-search` tool for semantic vector search. It embeds the query text at query time inside Neo4j via the GenAI plugin (`ai.text.embed`) and returns the most similar nodes with similarity scores. Embedding providers (OpenAI, Azure OpenAI, Vertex AI, Bedrock Titan) are configured via `NEO4J_EMBEDDING_*` environment variables; the tool is only registered when an embedding provider is configured. Supports structured metadata filters and is version-aware (uses the `SEARCH` clause on Neo4j 2026.01+, falling back to `db.index.vector.queryNodes()` on 2025.x).'
+time: 2026-06-26T00:00:00.000000-00:00

--- a/.changes/unreleased/Patch-vector-search-embed-fallback.yaml
+++ b/.changes/unreleased/Patch-vector-search-embed-fallback.yaml
@@ -1,0 +1,3 @@
+kind: Patch
+body: 'Fix `vector-search` on Neo4j versions older than 2025.11 (including current Neo4j Aura 5.x releases), where the GenAI plugin does not yet have `ai.text.embed()`. The tool now detects the Neo4j version and automatically falls back to the deprecated-but-present `genai.vector.encode()` function, with its PascalCase provider names and config keys, so embedding continues to work with no user action needed.'
+time: 2026-07-03T09:22:16.000000-00:00

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ dist/
 CLAUDE.md
 gemini.md
 *.pem
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ By implementing the Model Context Protocol (MCP), it acts as a bridge between an
 - `read-cypher` — execute read-only Cypher queries that do not modify database data, enforced via `EXPLAIN` and Neo4j's query-type classification. **Note:** custom procedures or functions incorrectly classified as read-only by Neo4j may bypass this check; ensuring correct classification is the responsibility of the procedure/function maintainer.
 - `write-cypher` — execute write Cypher queries (disabled if `NEO4J_READ_ONLY=true`)
 - `list-gds-procedures` — list available GDS procedures
+- `vector-search` — semantic vector search over a Neo4j vector index. Embeds the query text at query time (via the Neo4j GenAI plugin) and returns the most similar nodes with similarity scores, with optional metadata filters. Only registered when an embedding provider is configured (see [Vector search configuration](#vector-search-configuration)).
 
 ## Installation
 
@@ -57,6 +58,44 @@ Create / edit `mcp.json`:
 ```
 
 See [MCP documentation > Configuration](https://neo4j.com/docs/mcp/current/configuration) for more details.
+
+## Vector search configuration
+
+The `vector-search` tool is enabled only when an embedding provider is configured. The
+server embeds the query text inside Neo4j using the GenAI plugin, so the target instance
+must have the GenAI plugin available (standard on Neo4j Aura) and at least one vector
+index. It uses the GenAI plugin's `ai.text.embed()` function on Neo4j 2025.11 and later,
+and automatically falls back to the deprecated-but-present `genai.vector.encode()`
+function on older versions — including the 5.x releases currently deployed on Neo4j Aura —
+so no user action is needed. The embedding **model must match the model used to
+create the stored embeddings**, otherwise similarity scores are meaningless.
+
+Configure via environment variables:
+
+| Variable | Applies to | Description |
+|---|---|---|
+| `NEO4J_EMBEDDING_PROVIDER` | all | `openai`, `azure-openai`, `vertexai`, or `bedrock-titan`. Empty disables `vector-search`. |
+| `NEO4J_EMBEDDING_MODEL` | all | Embedding model id, e.g. `text-embedding-3-small`. |
+| `NEO4J_EMBEDDING_API_KEY` | openai, azure-openai, vertexai | Provider API token. |
+| `NEO4J_EMBEDDING_DIMENSIONS` | optional | Output dimensions, only if your model/index uses a reduced size. |
+| `NEO4J_EMBEDDING_AZURE_RESOURCE` | azure-openai | Azure resource name. |
+| `NEO4J_EMBEDDING_VERTEX_PROJECT` | vertexai | Google Cloud project id. |
+| `NEO4J_EMBEDDING_VERTEX_REGION` | vertexai | GCP region. |
+| `NEO4J_EMBEDDING_VERTEX_PUBLISHER` | vertexai | Optional, defaults to `google`. |
+| `NEO4J_EMBEDDING_AWS_ACCESS_KEY_ID` | bedrock-titan | AWS access key id. |
+| `NEO4J_EMBEDDING_AWS_SECRET_ACCESS_KEY` | bedrock-titan | AWS secret access key. |
+| `NEO4J_EMBEDDING_AWS_REGION` | bedrock-titan | AWS region. |
+
+The API key is read only from the server environment, is passed to Neo4j as a bound query
+parameter (obfuscated in the query log), and is never accepted as a tool input or returned
+to clients. In production deployments, source it from a secret manager rather than plain
+text. Example (OpenAI) for an `mcp.json` `env` block:
+
+```json
+"NEO4J_EMBEDDING_PROVIDER": "openai",
+"NEO4J_EMBEDDING_MODEL": "text-embedding-3-small",
+"NEO4J_EMBEDDING_API_KEY": "sk-..."
+```
 
 ## Links
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,7 +23,29 @@ const (
 	TransportModeStdio        TransportMode = "stdio"
 	TransportModeHTTP         TransportMode = "http"
 	DeprecatedVariableMessage string        = "Warning: deprecated environment variable \"%s\". Please use: \"%s\" instead\n"
+
+	// Embedding provider constants
+	EmbeddingProviderOpenAI       = "openai"
+	EmbeddingProviderAzureOpenAI  = "azure-openai"
+	EmbeddingProviderVertexAI     = "vertexai"
+	EmbeddingProviderBedrockTitan = "bedrock-titan"
 )
+
+// EmbeddingConfig holds optional embedding provider configuration.
+// All fields are optional; an empty Provider means embedding is disabled.
+type EmbeddingConfig struct {
+	Provider           string
+	Model              string
+	APIKey             string
+	Dimensions         string
+	AzureResource      string
+	VertexProject      string
+	VertexRegion       string
+	VertexPublisher    string
+	AWSAccessKeyID     string
+	AWSSecretAccessKey string
+	AWSRegion          string
+}
 
 // ValidTransportModes defines the allowed transport mode values
 var ValidTransportModes = []TransportMode{TransportModeStdio, TransportModeHTTP}
@@ -49,6 +71,33 @@ type Config struct {
 	AuthHeaderName                string        // HTTP header name to read auth credentials from (default: "Authorization")
 	AllowUnauthenticatedPing      bool          // If true, allows unauthenticated ping health checks in HTTP mode
 	AllowUnauthenticatedToolsList bool          // If true, allows unauthenticated tools list in HTTP mode
+	embeddingCfg                  EmbeddingConfig
+}
+
+// EmbeddingConfig returns the embedding provider configuration.
+func (c *Config) EmbeddingConfig() EmbeddingConfig {
+	return c.embeddingCfg
+}
+
+// IsEmbeddingConfigured returns true only when Provider is non-empty and all
+// required credentials for that provider are present.
+func (c *Config) IsEmbeddingConfigured() bool {
+	emb := c.embeddingCfg
+	if emb.Provider == "" {
+		return false
+	}
+	switch emb.Provider {
+	case EmbeddingProviderOpenAI:
+		return emb.Model != "" && emb.APIKey != ""
+	case EmbeddingProviderAzureOpenAI:
+		return emb.Model != "" && emb.APIKey != "" && emb.AzureResource != ""
+	case EmbeddingProviderVertexAI:
+		return emb.Model != "" && emb.APIKey != "" && emb.VertexProject != "" && emb.VertexRegion != ""
+	case EmbeddingProviderBedrockTitan:
+		return emb.Model != "" && emb.AWSAccessKeyID != "" && emb.AWSSecretAccessKey != "" && emb.AWSRegion != ""
+	default:
+		return false
+	}
 }
 
 // Validate validates the configuration and returns an error if invalid
@@ -101,6 +150,74 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	// Validate embedding configuration only when a provider is set
+	if err := validateEmbeddingConfig(c.embeddingCfg); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateEmbeddingConfig validates the embedding configuration.
+// If Provider is empty, embedding is disabled and no error is returned.
+func validateEmbeddingConfig(emb EmbeddingConfig) error {
+	if emb.Provider == "" {
+		return nil
+	}
+
+	switch emb.Provider {
+	case EmbeddingProviderOpenAI:
+		if emb.Model == "" {
+			return fmt.Errorf("NEO4J_EMBEDDING_MODEL is required when NEO4J_EMBEDDING_PROVIDER is '%s'", emb.Provider)
+		}
+		if emb.APIKey == "" {
+			return fmt.Errorf("NEO4J_EMBEDDING_API_KEY is required when NEO4J_EMBEDDING_PROVIDER is '%s'", emb.Provider)
+		}
+	case EmbeddingProviderAzureOpenAI:
+		if emb.Model == "" {
+			return fmt.Errorf("NEO4J_EMBEDDING_MODEL is required when NEO4J_EMBEDDING_PROVIDER is '%s'", emb.Provider)
+		}
+		if emb.APIKey == "" {
+			return fmt.Errorf("NEO4J_EMBEDDING_API_KEY is required when NEO4J_EMBEDDING_PROVIDER is '%s'", emb.Provider)
+		}
+		if emb.AzureResource == "" {
+			return fmt.Errorf("NEO4J_EMBEDDING_AZURE_RESOURCE is required when NEO4J_EMBEDDING_PROVIDER is '%s'", emb.Provider)
+		}
+	case EmbeddingProviderVertexAI:
+		if emb.Model == "" {
+			return fmt.Errorf("NEO4J_EMBEDDING_MODEL is required when NEO4J_EMBEDDING_PROVIDER is '%s'", emb.Provider)
+		}
+		if emb.APIKey == "" {
+			return fmt.Errorf("NEO4J_EMBEDDING_API_KEY is required when NEO4J_EMBEDDING_PROVIDER is '%s'", emb.Provider)
+		}
+		if emb.VertexProject == "" {
+			return fmt.Errorf("NEO4J_EMBEDDING_VERTEX_PROJECT is required when NEO4J_EMBEDDING_PROVIDER is '%s'", emb.Provider)
+		}
+		if emb.VertexRegion == "" {
+			return fmt.Errorf("NEO4J_EMBEDDING_VERTEX_REGION is required when NEO4J_EMBEDDING_PROVIDER is '%s'", emb.Provider)
+		}
+	case EmbeddingProviderBedrockTitan:
+		if emb.Model == "" {
+			return fmt.Errorf("NEO4J_EMBEDDING_MODEL is required when NEO4J_EMBEDDING_PROVIDER is '%s'", emb.Provider)
+		}
+		if emb.AWSAccessKeyID == "" {
+			return fmt.Errorf("NEO4J_EMBEDDING_AWS_ACCESS_KEY_ID is required when NEO4J_EMBEDDING_PROVIDER is '%s'", emb.Provider)
+		}
+		if emb.AWSSecretAccessKey == "" {
+			return fmt.Errorf("NEO4J_EMBEDDING_AWS_SECRET_ACCESS_KEY is required when NEO4J_EMBEDDING_PROVIDER is '%s'", emb.Provider)
+		}
+		if emb.AWSRegion == "" {
+			return fmt.Errorf("NEO4J_EMBEDDING_AWS_REGION is required when NEO4J_EMBEDDING_PROVIDER is '%s'", emb.Provider)
+		}
+	default:
+		return fmt.Errorf("invalid NEO4J_EMBEDDING_PROVIDER '%s', must be one of: %s, %s, %s, %s",
+			emb.Provider,
+			EmbeddingProviderOpenAI,
+			EmbeddingProviderAzureOpenAI,
+			EmbeddingProviderVertexAI,
+			EmbeddingProviderBedrockTitan,
+		)
+	}
 	return nil
 }
 
@@ -167,6 +284,19 @@ func LoadConfig(cliOverrides *CLIOverrides) (*Config, error) {
 		AuthHeaderName:                GetEnvWithDefault("NEO4J_HTTP_AUTH_HEADER_NAME", "Authorization"),
 		AllowUnauthenticatedPing:      ParseBool(GetEnv("NEO4J_HTTP_ALLOW_UNAUTHENTICATED_PING"), false),
 		AllowUnauthenticatedToolsList: ParseBool(GetEnv("NEO4J_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST"), false),
+		embeddingCfg: EmbeddingConfig{
+			Provider:           GetEnv("NEO4J_EMBEDDING_PROVIDER"),
+			Model:              GetEnv("NEO4J_EMBEDDING_MODEL"),
+			APIKey:             GetEnv("NEO4J_EMBEDDING_API_KEY"),
+			Dimensions:         GetEnv("NEO4J_EMBEDDING_DIMENSIONS"),
+			AzureResource:      GetEnv("NEO4J_EMBEDDING_AZURE_RESOURCE"),
+			VertexProject:      GetEnv("NEO4J_EMBEDDING_VERTEX_PROJECT"),
+			VertexRegion:       GetEnv("NEO4J_EMBEDDING_VERTEX_REGION"),
+			VertexPublisher:    GetEnv("NEO4J_EMBEDDING_VERTEX_PUBLISHER"),
+			AWSAccessKeyID:     GetEnv("NEO4J_EMBEDDING_AWS_ACCESS_KEY_ID"),
+			AWSSecretAccessKey: GetEnv("NEO4J_EMBEDDING_AWS_SECRET_ACCESS_KEY"),
+			AWSRegion:          GetEnv("NEO4J_EMBEDDING_AWS_REGION"),
+		},
 	}
 
 	// Apply CLI overrides if provided

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/neo4j/mcp/internal/testutil"
 )
 
+// testVertexToken is a non-secret placeholder used as the embedding credential in
+// EmbeddingConfig struct fixtures. It is a variable (not a string literal in each
+// struct) to avoid gosec G101 false positives on hardcoded credentials in tests.
+var testVertexToken = "placeholder-token"
+
 func TestConfig_Validate(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -844,4 +849,531 @@ func TestLoadConfig_AuthHeaderName(t *testing.T) {
 			t.Errorf("LoadConfig() error = %v, want error containing 'invalid auth header name'", err)
 		}
 	})
+}
+
+// setBaseEnv sets the minimum env vars needed for LoadConfig to pass basic validation
+// so embedding tests can focus on embedding-specific behaviour.
+func setBaseEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("NEO4J_TRANSPORT_MODE", "stdio")
+	t.Setenv("NEO4J_URI", "bolt://localhost:7687")
+	t.Setenv("NEO4J_USERNAME", "testuser")
+	t.Setenv("NEO4J_PASSWORD", "testpass")
+}
+
+func TestEmbeddingConfig_NoProvider(t *testing.T) {
+	setBaseEnv(t)
+	// Ensure embedding env vars are absent
+	t.Setenv("NEO4J_EMBEDDING_PROVIDER", "")
+
+	cfg, err := LoadConfig(nil)
+	if err != nil {
+		t.Fatalf("LoadConfig() unexpected error: %v", err)
+	}
+
+	emb := cfg.EmbeddingConfig()
+	if emb.Provider != "" {
+		t.Errorf("EmbeddingConfig().Provider = %q, want empty", emb.Provider)
+	}
+	if cfg.IsEmbeddingConfigured() {
+		t.Error("IsEmbeddingConfigured() = true, want false when no provider set")
+	}
+}
+
+func TestEmbeddingConfig_OpenAI_FullyConfigured(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("NEO4J_EMBEDDING_PROVIDER", "openai")
+	t.Setenv("NEO4J_EMBEDDING_MODEL", "text-embedding-3-small")
+	t.Setenv("NEO4J_EMBEDDING_API_KEY", "sk-test-key")
+	t.Setenv("NEO4J_EMBEDDING_DIMENSIONS", "1536")
+
+	cfg, err := LoadConfig(nil)
+	if err != nil {
+		t.Fatalf("LoadConfig() unexpected error: %v", err)
+	}
+
+	emb := cfg.EmbeddingConfig()
+	if emb.Provider != EmbeddingProviderOpenAI {
+		t.Errorf("EmbeddingConfig().Provider = %q, want %q", emb.Provider, EmbeddingProviderOpenAI)
+	}
+	if emb.Model != "text-embedding-3-small" {
+		t.Errorf("EmbeddingConfig().Model = %q, want 'text-embedding-3-small'", emb.Model)
+	}
+	if emb.APIKey != "sk-test-key" {
+		t.Errorf("EmbeddingConfig().APIKey = %q, want 'sk-test-key'", emb.APIKey)
+	}
+	if emb.Dimensions != "1536" {
+		t.Errorf("EmbeddingConfig().Dimensions = %q, want '1536'", emb.Dimensions)
+	}
+	if !cfg.IsEmbeddingConfigured() {
+		t.Error("IsEmbeddingConfigured() = false, want true for fully configured openai")
+	}
+}
+
+func TestEmbeddingConfig_AzureOpenAI_FullyConfigured(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("NEO4J_EMBEDDING_PROVIDER", "azure-openai")
+	t.Setenv("NEO4J_EMBEDDING_MODEL", "text-embedding-ada-002")
+	t.Setenv("NEO4J_EMBEDDING_API_KEY", "azure-key")
+	t.Setenv("NEO4J_EMBEDDING_AZURE_RESOURCE", "my-azure-resource")
+
+	cfg, err := LoadConfig(nil)
+	if err != nil {
+		t.Fatalf("LoadConfig() unexpected error: %v", err)
+	}
+
+	emb := cfg.EmbeddingConfig()
+	if emb.Provider != EmbeddingProviderAzureOpenAI {
+		t.Errorf("EmbeddingConfig().Provider = %q, want %q", emb.Provider, EmbeddingProviderAzureOpenAI)
+	}
+	if emb.AzureResource != "my-azure-resource" {
+		t.Errorf("EmbeddingConfig().AzureResource = %q, want 'my-azure-resource'", emb.AzureResource)
+	}
+	if !cfg.IsEmbeddingConfigured() {
+		t.Error("IsEmbeddingConfigured() = false, want true for fully configured azure-openai")
+	}
+}
+
+func TestEmbeddingConfig_VertexAI_FullyConfigured(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("NEO4J_EMBEDDING_PROVIDER", "vertexai")
+	t.Setenv("NEO4J_EMBEDDING_MODEL", "textembedding-gecko")
+	t.Setenv("NEO4J_EMBEDDING_API_KEY", "vertex-token")
+	t.Setenv("NEO4J_EMBEDDING_VERTEX_PROJECT", "my-gcp-project")
+	t.Setenv("NEO4J_EMBEDDING_VERTEX_REGION", "us-central1")
+	t.Setenv("NEO4J_EMBEDDING_VERTEX_PUBLISHER", "google")
+
+	cfg, err := LoadConfig(nil)
+	if err != nil {
+		t.Fatalf("LoadConfig() unexpected error: %v", err)
+	}
+
+	emb := cfg.EmbeddingConfig()
+	if emb.Provider != EmbeddingProviderVertexAI {
+		t.Errorf("EmbeddingConfig().Provider = %q, want %q", emb.Provider, EmbeddingProviderVertexAI)
+	}
+	if emb.VertexProject != "my-gcp-project" {
+		t.Errorf("EmbeddingConfig().VertexProject = %q, want 'my-gcp-project'", emb.VertexProject)
+	}
+	if emb.VertexRegion != "us-central1" {
+		t.Errorf("EmbeddingConfig().VertexRegion = %q, want 'us-central1'", emb.VertexRegion)
+	}
+	if emb.VertexPublisher != "google" {
+		t.Errorf("EmbeddingConfig().VertexPublisher = %q, want 'google'", emb.VertexPublisher)
+	}
+	if !cfg.IsEmbeddingConfigured() {
+		t.Error("IsEmbeddingConfigured() = false, want true for fully configured vertexai")
+	}
+}
+
+func TestEmbeddingConfig_BedrockTitan_FullyConfigured(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("NEO4J_EMBEDDING_PROVIDER", "bedrock-titan")
+	t.Setenv("NEO4J_EMBEDDING_MODEL", "amazon.titan-embed-text-v1")
+	t.Setenv("NEO4J_EMBEDDING_AWS_ACCESS_KEY_ID", "test-access-key-id")
+	t.Setenv("NEO4J_EMBEDDING_AWS_SECRET_ACCESS_KEY", "test-secret-access-key")
+	t.Setenv("NEO4J_EMBEDDING_AWS_REGION", "us-east-1")
+
+	cfg, err := LoadConfig(nil)
+	if err != nil {
+		t.Fatalf("LoadConfig() unexpected error: %v", err)
+	}
+
+	emb := cfg.EmbeddingConfig()
+	if emb.Provider != EmbeddingProviderBedrockTitan {
+		t.Errorf("EmbeddingConfig().Provider = %q, want %q", emb.Provider, EmbeddingProviderBedrockTitan)
+	}
+	if emb.AWSAccessKeyID != "test-access-key-id" {
+		t.Errorf("EmbeddingConfig().AWSAccessKeyID = %q, want 'test-access-key-id'", emb.AWSAccessKeyID)
+	}
+	if emb.AWSSecretAccessKey != "test-secret-access-key" {
+		t.Errorf("EmbeddingConfig().AWSSecretAccessKey = %q, want 'test-secret-access-key'", emb.AWSSecretAccessKey)
+	}
+	if emb.AWSRegion != "us-east-1" {
+		t.Errorf("EmbeddingConfig().AWSRegion = %q, want 'us-east-1'", emb.AWSRegion)
+	}
+	if !cfg.IsEmbeddingConfigured() {
+		t.Error("IsEmbeddingConfigured() = false, want true for fully configured bedrock-titan")
+	}
+}
+
+func TestEmbeddingConfig_UnknownProvider_ValidateError(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("NEO4J_EMBEDDING_PROVIDER", "unknown-provider")
+
+	cfg, err := LoadConfig(nil)
+	if err == nil {
+		t.Error("LoadConfig() expected error for unknown provider, got nil")
+		_ = cfg
+		return
+	}
+	if !strings.Contains(err.Error(), "invalid NEO4J_EMBEDDING_PROVIDER") {
+		t.Errorf("LoadConfig() error = %v, want error containing 'invalid NEO4J_EMBEDDING_PROVIDER'", err)
+	}
+}
+
+func TestEmbeddingConfig_Validate_MissingFields(t *testing.T) {
+	tests := []struct {
+		name          string
+		envVars       map[string]string
+		wantErrSubstr string
+	}{
+		{
+			name: "openai missing model",
+			envVars: map[string]string{
+				"NEO4J_EMBEDDING_PROVIDER": "openai",
+				"NEO4J_EMBEDDING_API_KEY":  "sk-key",
+			},
+			wantErrSubstr: "NEO4J_EMBEDDING_MODEL",
+		},
+		{
+			name: "openai missing api key",
+			envVars: map[string]string{
+				"NEO4J_EMBEDDING_PROVIDER": "openai",
+				"NEO4J_EMBEDDING_MODEL":    "text-embedding-3-small",
+			},
+			wantErrSubstr: "NEO4J_EMBEDDING_API_KEY",
+		},
+		{
+			name: "azure-openai missing model",
+			envVars: map[string]string{
+				"NEO4J_EMBEDDING_PROVIDER":       "azure-openai",
+				"NEO4J_EMBEDDING_API_KEY":        "azure-key",
+				"NEO4J_EMBEDDING_AZURE_RESOURCE": "my-resource",
+			},
+			wantErrSubstr: "NEO4J_EMBEDDING_MODEL",
+		},
+		{
+			name: "azure-openai missing api key",
+			envVars: map[string]string{
+				"NEO4J_EMBEDDING_PROVIDER":       "azure-openai",
+				"NEO4J_EMBEDDING_MODEL":          "text-embedding-ada-002",
+				"NEO4J_EMBEDDING_AZURE_RESOURCE": "my-resource",
+			},
+			wantErrSubstr: "NEO4J_EMBEDDING_API_KEY",
+		},
+		{
+			name: "azure-openai missing azure resource",
+			envVars: map[string]string{
+				"NEO4J_EMBEDDING_PROVIDER": "azure-openai",
+				"NEO4J_EMBEDDING_MODEL":    "text-embedding-ada-002",
+				"NEO4J_EMBEDDING_API_KEY":  "azure-key",
+			},
+			wantErrSubstr: "NEO4J_EMBEDDING_AZURE_RESOURCE",
+		},
+		{
+			name: "vertexai missing model",
+			envVars: map[string]string{
+				"NEO4J_EMBEDDING_PROVIDER":       "vertexai",
+				"NEO4J_EMBEDDING_API_KEY":        "vertex-token",
+				"NEO4J_EMBEDDING_VERTEX_PROJECT": "my-project",
+				"NEO4J_EMBEDDING_VERTEX_REGION":  "us-central1",
+			},
+			wantErrSubstr: "NEO4J_EMBEDDING_MODEL",
+		},
+		{
+			name: "vertexai missing api key",
+			envVars: map[string]string{
+				"NEO4J_EMBEDDING_PROVIDER":       "vertexai",
+				"NEO4J_EMBEDDING_MODEL":          "textembedding-gecko",
+				"NEO4J_EMBEDDING_VERTEX_PROJECT": "my-project",
+				"NEO4J_EMBEDDING_VERTEX_REGION":  "us-central1",
+			},
+			wantErrSubstr: "NEO4J_EMBEDDING_API_KEY",
+		},
+		{
+			name: "vertexai missing project",
+			envVars: map[string]string{
+				"NEO4J_EMBEDDING_PROVIDER":      "vertexai",
+				"NEO4J_EMBEDDING_MODEL":         "textembedding-gecko",
+				"NEO4J_EMBEDDING_API_KEY":       "vertex-token",
+				"NEO4J_EMBEDDING_VERTEX_REGION": "us-central1",
+			},
+			wantErrSubstr: "NEO4J_EMBEDDING_VERTEX_PROJECT",
+		},
+		{
+			name: "vertexai missing region",
+			envVars: map[string]string{
+				"NEO4J_EMBEDDING_PROVIDER":       "vertexai",
+				"NEO4J_EMBEDDING_MODEL":          "textembedding-gecko",
+				"NEO4J_EMBEDDING_API_KEY":        "vertex-token",
+				"NEO4J_EMBEDDING_VERTEX_PROJECT": "my-project",
+			},
+			wantErrSubstr: "NEO4J_EMBEDDING_VERTEX_REGION",
+		},
+		{
+			name: "bedrock-titan missing model",
+			envVars: map[string]string{
+				"NEO4J_EMBEDDING_PROVIDER":              "bedrock-titan",
+				"NEO4J_EMBEDDING_AWS_ACCESS_KEY_ID":     "AKID",
+				"NEO4J_EMBEDDING_AWS_SECRET_ACCESS_KEY": "SECRET",
+				"NEO4J_EMBEDDING_AWS_REGION":            "us-east-1",
+			},
+			wantErrSubstr: "NEO4J_EMBEDDING_MODEL",
+		},
+		{
+			name: "bedrock-titan missing access key id",
+			envVars: map[string]string{
+				"NEO4J_EMBEDDING_PROVIDER":              "bedrock-titan",
+				"NEO4J_EMBEDDING_MODEL":                 "amazon.titan-embed-text-v1",
+				"NEO4J_EMBEDDING_AWS_SECRET_ACCESS_KEY": "SECRET",
+				"NEO4J_EMBEDDING_AWS_REGION":            "us-east-1",
+			},
+			wantErrSubstr: "NEO4J_EMBEDDING_AWS_ACCESS_KEY_ID",
+		},
+		{
+			name: "bedrock-titan missing secret access key",
+			envVars: map[string]string{
+				"NEO4J_EMBEDDING_PROVIDER":          "bedrock-titan",
+				"NEO4J_EMBEDDING_MODEL":             "amazon.titan-embed-text-v1",
+				"NEO4J_EMBEDDING_AWS_ACCESS_KEY_ID": "AKID",
+				"NEO4J_EMBEDDING_AWS_REGION":        "us-east-1",
+			},
+			wantErrSubstr: "NEO4J_EMBEDDING_AWS_SECRET_ACCESS_KEY",
+		},
+		{
+			name: "bedrock-titan missing region",
+			envVars: map[string]string{
+				"NEO4J_EMBEDDING_PROVIDER":              "bedrock-titan",
+				"NEO4J_EMBEDDING_MODEL":                 "amazon.titan-embed-text-v1",
+				"NEO4J_EMBEDDING_AWS_ACCESS_KEY_ID":     "AKID",
+				"NEO4J_EMBEDDING_AWS_SECRET_ACCESS_KEY": "SECRET",
+			},
+			wantErrSubstr: "NEO4J_EMBEDDING_AWS_REGION",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setBaseEnv(t)
+			// Clear all embedding vars first, then set test-specific ones
+			for _, key := range []string{
+				"NEO4J_EMBEDDING_PROVIDER",
+				"NEO4J_EMBEDDING_MODEL",
+				"NEO4J_EMBEDDING_API_KEY",
+				"NEO4J_EMBEDDING_DIMENSIONS",
+				"NEO4J_EMBEDDING_AZURE_RESOURCE",
+				"NEO4J_EMBEDDING_VERTEX_PROJECT",
+				"NEO4J_EMBEDDING_VERTEX_REGION",
+				"NEO4J_EMBEDDING_VERTEX_PUBLISHER",
+				"NEO4J_EMBEDDING_AWS_ACCESS_KEY_ID",
+				"NEO4J_EMBEDDING_AWS_SECRET_ACCESS_KEY",
+				"NEO4J_EMBEDDING_AWS_REGION",
+			} {
+				t.Setenv(key, "")
+			}
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+
+			cfg, err := LoadConfig(nil)
+			if err == nil {
+				t.Errorf("LoadConfig() expected error for %s, got nil", tt.name)
+				_ = cfg
+				return
+			}
+			if !strings.Contains(err.Error(), tt.wantErrSubstr) {
+				t.Errorf("LoadConfig() error = %v, want error containing %q", err, tt.wantErrSubstr)
+			}
+		})
+	}
+}
+
+func TestIsEmbeddingConfigured_MissingFields(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  EmbeddingConfig
+		want bool
+	}{
+		{
+			name: "empty provider",
+			cfg:  EmbeddingConfig{},
+			want: false,
+		},
+		{
+			name: "openai fully configured",
+			cfg: EmbeddingConfig{
+				Provider: EmbeddingProviderOpenAI,
+				Model:    "text-embedding-3-small",
+				APIKey:   "sk-key",
+			},
+			want: true,
+		},
+		{
+			name: "openai missing model",
+			cfg: EmbeddingConfig{
+				Provider: EmbeddingProviderOpenAI,
+				APIKey:   "sk-key",
+			},
+			want: false,
+		},
+		{
+			name: "openai missing api key",
+			cfg: EmbeddingConfig{
+				Provider: EmbeddingProviderOpenAI,
+				Model:    "text-embedding-3-small",
+			},
+			want: false,
+		},
+		{
+			name: "azure-openai fully configured",
+			cfg: EmbeddingConfig{
+				Provider:      EmbeddingProviderAzureOpenAI,
+				Model:         "text-embedding-ada-002",
+				APIKey:        "azure-key",
+				AzureResource: "my-resource",
+			},
+			want: true,
+		},
+		{
+			name: "azure-openai missing resource",
+			cfg: EmbeddingConfig{
+				Provider: EmbeddingProviderAzureOpenAI,
+				Model:    "text-embedding-ada-002",
+				APIKey:   "azure-key",
+			},
+			want: false,
+		},
+		{
+			name: "vertexai fully configured",
+			cfg: EmbeddingConfig{
+				Provider:      EmbeddingProviderVertexAI,
+				Model:         "textembedding-gecko",
+				APIKey:        testVertexToken,
+				VertexProject: "my-project",
+				VertexRegion:  "us-central1",
+			},
+			want: true,
+		},
+		{
+			name: "vertexai missing region",
+			cfg: EmbeddingConfig{
+				Provider:      EmbeddingProviderVertexAI,
+				Model:         "textembedding-gecko",
+				APIKey:        testVertexToken,
+				VertexProject: "my-project",
+			},
+			want: false,
+		},
+		{
+			name: "bedrock-titan fully configured",
+			cfg: EmbeddingConfig{
+				Provider:           EmbeddingProviderBedrockTitan,
+				Model:              "amazon.titan-embed-text-v1",
+				AWSAccessKeyID:     "AKID",
+				AWSSecretAccessKey: "SECRET",
+				AWSRegion:          "us-east-1",
+			},
+			want: true,
+		},
+		{
+			name: "bedrock-titan missing region",
+			cfg: EmbeddingConfig{
+				Provider:           EmbeddingProviderBedrockTitan,
+				Model:              "amazon.titan-embed-text-v1",
+				AWSAccessKeyID:     "AKID",
+				AWSSecretAccessKey: "SECRET",
+			},
+			want: false,
+		},
+		{
+			name: "unknown provider",
+			cfg: EmbeddingConfig{
+				Provider: "unknown",
+				Model:    "some-model",
+				APIKey:   "some-key",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Config{embeddingCfg: tt.cfg}
+			got := c.IsEmbeddingConfigured()
+			if got != tt.want {
+				t.Errorf("IsEmbeddingConfigured() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEmbeddingConfig_Validate_NoProviderNoError(t *testing.T) {
+	// Validate that an existing deployment with no embedding vars passes validation
+	cfg := &Config{
+		URI:           "bolt://localhost:7687",
+		Username:      "neo4j",
+		Password:      "password",
+		TransportMode: TransportModeStdio,
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() unexpected error for config with no embedding provider: %v", err)
+	}
+}
+
+func TestEmbeddingConfig_Validate_UnknownProvider_DirectValidate(t *testing.T) {
+	cfg := &Config{
+		URI:           "bolt://localhost:7687",
+		Username:      "neo4j",
+		Password:      "password",
+		TransportMode: TransportModeStdio,
+		embeddingCfg: EmbeddingConfig{
+			Provider: "not-a-real-provider",
+			Model:    "some-model",
+			APIKey:   "some-key",
+		},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() expected error for unknown embedding provider, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid NEO4J_EMBEDDING_PROVIDER") {
+		t.Errorf("Validate() error = %v, want error containing 'invalid NEO4J_EMBEDDING_PROVIDER'", err)
+	}
+}
+
+func TestEmbeddingConfig_VertexPublisher_Optional(t *testing.T) {
+	// VertexPublisher is optional — vertexai should be fully configured without it
+	setBaseEnv(t)
+	t.Setenv("NEO4J_EMBEDDING_PROVIDER", "vertexai")
+	t.Setenv("NEO4J_EMBEDDING_MODEL", "textembedding-gecko")
+	t.Setenv("NEO4J_EMBEDDING_API_KEY", "vertex-token")
+	t.Setenv("NEO4J_EMBEDDING_VERTEX_PROJECT", "my-project")
+	t.Setenv("NEO4J_EMBEDDING_VERTEX_REGION", "us-central1")
+	// NEO4J_EMBEDDING_VERTEX_PUBLISHER intentionally not set
+
+	cfg, err := LoadConfig(nil)
+	if err != nil {
+		t.Fatalf("LoadConfig() unexpected error: %v", err)
+	}
+
+	emb := cfg.EmbeddingConfig()
+	if emb.VertexPublisher != "" {
+		t.Errorf("EmbeddingConfig().VertexPublisher = %q, want '' (optional, not set)", emb.VertexPublisher)
+	}
+	if !cfg.IsEmbeddingConfigured() {
+		t.Error("IsEmbeddingConfigured() = false, want true — VertexPublisher is optional")
+	}
+}
+
+func TestEmbeddingConfig_Dimensions_Optional(t *testing.T) {
+	// Dimensions is optional for all providers
+	setBaseEnv(t)
+	t.Setenv("NEO4J_EMBEDDING_PROVIDER", "openai")
+	t.Setenv("NEO4J_EMBEDDING_MODEL", "text-embedding-3-small")
+	t.Setenv("NEO4J_EMBEDDING_API_KEY", "sk-key")
+	// NEO4J_EMBEDDING_DIMENSIONS intentionally not set
+
+	cfg, err := LoadConfig(nil)
+	if err != nil {
+		t.Fatalf("LoadConfig() unexpected error: %v", err)
+	}
+
+	emb := cfg.EmbeddingConfig()
+	if emb.Dimensions != "" {
+		t.Errorf("EmbeddingConfig().Dimensions = %q, want '' (optional, not set)", emb.Dimensions)
+	}
+	if !cfg.IsEmbeddingConfigured() {
+		t.Error("IsEmbeddingConfigured() = false, want true — Dimensions is optional")
+	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -47,6 +48,9 @@ type Neo4jMCPServer struct {
 	version            string
 	anService          analytics.Service
 	gdsInstalled       bool
+	useSearchClause    atomic.Bool
+	useAiTextEmbed     atomic.Bool
+	connInfo           analytics.ConnectionEventInfo
 	initMu             sync.Mutex
 	connectionVerified atomic.Bool
 }
@@ -197,6 +201,27 @@ func (s *Neo4jMCPServer) verifyRequirements(ctx context.Context) error {
 	if !ok || !apocMetaSchemaAvailable {
 		return fmt.Errorf("please ensure the APOC plugin is installed and includes the 'meta' component")
 	}
+
+	// Determine the Neo4j version to select the vector-search query strategy.
+	// The SEARCH clause is available from Neo4j 2026.01; older versions use the
+	// db.index.vector.queryNodes() fallback. This is non-fatal: on any failure we
+	// default to the fallback.
+	versionRecords, versionErr := s.dbService.ExecuteReadQuery(ctx, "CALL dbms.components()", nil)
+	if versionErr != nil {
+		slog.Warn("could not determine Neo4j version; vector search will use the queryNodes fallback", "error", versionErr)
+		s.useSearchClause.Store(false)
+		s.useAiTextEmbed.Store(false)
+	} else {
+		// Cache the connection info so emitConnectionInitializedEvent can reuse it
+		// instead of issuing a second dbms.components() call.
+		s.connInfo = recordsToConnectionEventInfo(versionRecords)
+		useSearch := supportsSearchClause(s.connInfo.Neo4jVersion)
+		s.useSearchClause.Store(useSearch)
+		useAiEmbed := supportsAiTextEmbed(s.connInfo.Neo4jVersion)
+		s.useAiTextEmbed.Store(useAiEmbed)
+		slog.Info("vector search query strategy determined", "neo4jVersion", s.connInfo.Neo4jVersion, "useSearchClause", useSearch, "useAiTextEmbed", useAiEmbed)
+	}
+
 	// Call gds.version procedure to determine if GDS is installed
 	records, err = s.dbService.ExecuteReadQuery(ctx, "RETURN gds.version() as gdsVersion", nil)
 	if err != nil {
@@ -215,25 +240,86 @@ func (s *Neo4jMCPServer) verifyRequirements(ctx context.Context) error {
 	return nil
 }
 
+// supportsSearchClause reports whether the given Neo4j version supports the SEARCH
+// clause for vector indexes (introduced in Neo4j 2026.01). Calendar-versioned releases
+// from 2026 onward qualify (all 2026.x versions are >= 2026.01); legacy "5.x" and
+// "2025.x" releases do not. Unparseable or empty versions default to false, which
+// selects the safe db.index.vector.queryNodes() fallback.
+func supportsSearchClause(version string) bool {
+	// Take the leading run of digits (the major / calendar-year component).
+	i := 0
+	for i < len(version) && version[i] >= '0' && version[i] <= '9' {
+		i++
+	}
+	if i == 0 {
+		return false
+	}
+	major, err := strconv.Atoi(version[:i])
+	if err != nil {
+		return false
+	}
+	return major >= 2026
+}
+
+// supportsAiTextEmbed reports whether the given Neo4j version supports the
+// ai.text.embed / ai.text.embedBatch GenAI functions (introduced in Neo4j 2025.11).
+// Older calendar-versioned releases ("5.x", "2025.01"–"2025.10", and everything before)
+// do not have them and must fall back to the deprecated-but-present genai.vector.encode
+// function. Unparseable, empty, or missing-minor versions default to false, which
+// selects that safe genai.vector.encode fallback.
+func supportsAiTextEmbed(version string) bool {
+	// Take the leading run of digits (the major / calendar-year component).
+	i := 0
+	for i < len(version) && version[i] >= '0' && version[i] <= '9' {
+		i++
+	}
+	if i == 0 {
+		return false
+	}
+	major, err := strconv.Atoi(version[:i])
+	if err != nil {
+		return false
+	}
+	if major > 2025 {
+		return true
+	}
+	if major < 2025 {
+		return false
+	}
+
+	// major == 2025: need the minor component after the first '.'.
+	if i >= len(version) || version[i] != '.' {
+		return false
+	}
+	rest := version[i+1:]
+	j := 0
+	for j < len(rest) && rest[j] >= '0' && rest[j] <= '9' {
+		j++
+	}
+	if j == 0 {
+		return false
+	}
+	minor, err := strconv.Atoi(rest[:j])
+	if err != nil {
+		return false
+	}
+	return minor >= 11
+}
+
 // emitServerStartupEvent emits the server startup event immediately with available info (no DB query)
 func (s *Neo4jMCPServer) emitServerStartupEvent() {
 	s.anService.EmitEvent(s.anService.NewStartupEvent(s.config.TransportMode, s.config.HTTPTLSEnabled, s.version))
 }
 
 // emitConnectionInitializedEvent emits the connection initialized event with DB information (STDIO mode only)
-func (s *Neo4jMCPServer) emitConnectionInitializedEvent(ctx context.Context) {
+func (s *Neo4jMCPServer) emitConnectionInitializedEvent(_ context.Context) {
 	if !s.anService.IsEnabled() {
 		return
 	}
 
-	records, err := s.dbService.ExecuteReadQuery(ctx, "CALL dbms.components()", map[string]any{})
-	if err != nil {
-		slog.Debug("Failed to collect connection metadata", "error", err.Error())
-		return
-	}
-
-	connInfo := recordsToConnectionEventInfo(records)
-	s.anService.EmitEvent(s.anService.NewConnectionInitializedEvent(connInfo))
+	// Reuse the connection info collected during verifyRequirements (via dbms.components)
+	// rather than issuing a second query.
+	s.anService.EmitEvent(s.anService.NewConnectionInitializedEvent(s.connInfo))
 }
 
 // recordsToConnectionEventInfo converts dbms.components() records to ConnectionEventInfo
@@ -462,6 +548,12 @@ func (s *Neo4jMCPServer) configureHooks() *server.Hooks {
 			if s.gdsInstalled {
 				s.addGDSTools()
 			}
+
+			// Note: vector-search is registered at startup (gated by embedding config),
+			// not here. Its query strategy reads useSearchClause lazily at call time, so
+			// it appears in the initial tool list (required for clients such as Copilot
+			// Studio that import tools once) while still using the correct strategy after
+			// the version is detected above.
 
 			s.emitConnectionInitializedEvent(ctx)
 

--- a/internal/server/server_vector_test.go
+++ b/internal/server/server_vector_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+package server
+
+import (
+	"testing"
+
+	analytics "github.com/neo4j/mcp/internal/analytics/mocks"
+	"github.com/neo4j/mcp/internal/config"
+	db "github.com/neo4j/mcp/internal/database/mocks"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSupportsSearchClause(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"2026.01.0", true},
+		{"2026.04", true},
+		{"2026.12.1", true},
+		{"2027.1.0", true},
+		{"2025.11", false},
+		{"2025.01.0", false},
+		{"5.26.0", false},
+		{"5.18.0", false},
+		{"4.4.0", false},
+		{"unknown", false},
+		{"", false},
+		{"v2026.01", false}, // leading non-digit => unparseable => false
+	}
+	for _, c := range cases {
+		if got := supportsSearchClause(c.version); got != c.want {
+			t.Errorf("supportsSearchClause(%q) = %v, want %v", c.version, got, c.want)
+		}
+	}
+}
+
+func TestSupportsAiTextEmbed(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"5.27-aura", false},
+		{"5.26", false},
+		{"2024.12", false},
+		{"2025.01", false},
+		{"2025.10", false},
+		{"2025.11", true},
+		{"2025.12", true},
+		{"2026.01", true},
+		{"2027.05", true},
+		{"2025", false},
+		{"", false},
+		{"garbage", false},
+	}
+	for _, c := range cases {
+		if got := supportsAiTextEmbed(c.version); got != c.want {
+			t.Errorf("supportsAiTextEmbed(%q) = %v, want %v", c.version, got, c.want)
+		}
+	}
+}
+
+// toolNames returns the registered tool names as a set for readable assertions.
+func toolNames(s *Neo4jMCPServer) map[string]bool {
+	names := make(map[string]bool)
+	for name := range s.MCPServer.ListTools() {
+		names[name] = true
+	}
+	return names
+}
+
+// newEmbeddingConfiguredServer builds a server whose config has embedding fully
+// configured (OpenAI), for the given transport mode. The DB/analytics services are
+// mocked with no expectations because registerTools/addVectorTools perform no DB or
+// analytics calls.
+func newEmbeddingConfiguredServer(t *testing.T, transport config.TransportMode) (*Neo4jMCPServer, *gomock.Controller) {
+	t.Helper()
+	t.Setenv("NEO4J_URI", "bolt://test-host:7687")
+	t.Setenv("NEO4J_TRANSPORT_MODE", string(transport))
+	if transport == config.TransportModeStdio {
+		t.Setenv("NEO4J_USERNAME", "neo4j")
+		t.Setenv("NEO4J_PASSWORD", "password")
+	} else {
+		// HTTP mode must not have static credentials.
+		t.Setenv("NEO4J_USERNAME", "")
+		t.Setenv("NEO4J_PASSWORD", "")
+	}
+	t.Setenv("NEO4J_EMBEDDING_PROVIDER", config.EmbeddingProviderOpenAI)
+	t.Setenv("NEO4J_EMBEDDING_MODEL", "text-embedding-3-small")
+	t.Setenv("NEO4J_EMBEDDING_API_KEY", "test-key")
+
+	cfg, err := config.LoadConfig(nil)
+	if err != nil {
+		t.Fatalf("LoadConfig() failed: %v", err)
+	}
+	if !cfg.IsEmbeddingConfigured() {
+		t.Fatalf("expected embedding to be configured")
+	}
+
+	ctrl := gomock.NewController(t)
+	mockDB := db.NewMockService(ctrl)
+	aService := analytics.NewMockService(ctrl)
+	return NewNeo4jMCPServer("test-version", cfg, mockDB, aService), ctrl
+}
+
+func TestVectorToolRegistrationStdioConfigured(t *testing.T) {
+	s, ctrl := newEmbeddingConfiguredServer(t, config.TransportModeStdio)
+	defer ctrl.Finish()
+
+	if err := s.registerTools(); err != nil {
+		t.Fatalf("registerTools() failed: %v", err)
+	}
+	if names := toolNames(s); !names["vector-search"] {
+		t.Errorf("expected vector-search to be registered in stdio mode when embedding configured; got %v", names)
+	}
+}
+
+func TestVectorToolRegisteredInHTTPAtStartup(t *testing.T) {
+	s, ctrl := newEmbeddingConfiguredServer(t, config.TransportModeHTTP)
+	defer ctrl.Finish()
+
+	if err := s.registerTools(); err != nil {
+		t.Fatalf("registerTools() failed: %v", err)
+	}
+	// vector-search must be present in the INITIAL tool list (registered at startup, not
+	// deferred) so clients that import the tool list once — e.g. Copilot Studio — can see
+	// it. The version-dependent query strategy is resolved lazily at call time.
+	if names := toolNames(s); !names["vector-search"] {
+		t.Errorf("expected vector-search to be registered at HTTP startup when embedding configured; got %v", names)
+	}
+}
+
+func TestVectorToolAbsentWhenEmbeddingNotConfigured(t *testing.T) {
+	t.Setenv("NEO4J_URI", "bolt://test-host:7687")
+	t.Setenv("NEO4J_TRANSPORT_MODE", string(config.TransportModeStdio))
+	t.Setenv("NEO4J_USERNAME", "neo4j")
+	t.Setenv("NEO4J_PASSWORD", "password")
+	t.Setenv("NEO4J_EMBEDDING_PROVIDER", "") // embedding disabled
+
+	cfg, err := config.LoadConfig(nil)
+	if err != nil {
+		t.Fatalf("LoadConfig() failed: %v", err)
+	}
+	if cfg.IsEmbeddingConfigured() {
+		t.Fatalf("did not expect embedding to be configured")
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	s := NewNeo4jMCPServer("test-version", cfg, db.NewMockService(ctrl), analytics.NewMockService(ctrl))
+
+	if err := s.registerTools(); err != nil {
+		t.Fatalf("registerTools() failed: %v", err)
+	}
+	if names := toolNames(s); names["vector-search"] {
+		t.Errorf("expected vector-search to be absent when embedding not configured; got %v", names)
+	}
+}

--- a/internal/server/tools_register.go
+++ b/internal/server/tools_register.go
@@ -8,6 +8,7 @@ import (
 	"github.com/neo4j/mcp/internal/tools"
 	"github.com/neo4j/mcp/internal/tools/cypher"
 	"github.com/neo4j/mcp/internal/tools/gds"
+	"github.com/neo4j/mcp/internal/tools/vector"
 )
 
 // registerTools registers all enabled MCP tools and adds them to the provided MCP server.
@@ -29,6 +30,7 @@ type toolCategory int
 const (
 	cypherCategory toolCategory = 0
 	gdsCategory    toolCategory = 1
+	vectorCategory toolCategory = 2
 )
 
 type ToolDefinition struct {
@@ -67,6 +69,14 @@ func (s *Neo4jMCPServer) getEnabledTools() []server.ServerTool {
 	if !s.gdsInstalled {
 		filters = append(filters, filterGDSTools)
 	}
+	// Vector search is gated solely on embedding configuration, which is known at startup
+	// in both transport modes. It is registered at startup (not deferred) so it appears in
+	// the initial tool list — required for clients such as Copilot Studio that import the
+	// tool list once and do not re-fetch it after later registration changes. The
+	// version-dependent query strategy is resolved lazily at call time (see SearchHandler).
+	if s.config == nil || !s.config.IsEmbeddingConfigured() {
+		filters = append(filters, filterVectorTools)
+	}
 	deps := &tools.ToolDependencies{
 		DBService:        s.dbService,
 		AnalyticsService: s.anService,
@@ -103,6 +113,16 @@ func filterGDSTools(tools []ToolDefinition) []ToolDefinition {
 	return nonGDSTools
 }
 
+func filterVectorTools(tools []ToolDefinition) []ToolDefinition {
+	nonVectorTools := make([]ToolDefinition, 0, len(tools))
+	for _, t := range tools {
+		if t.category != vectorCategory {
+			nonVectorTools = append(nonVectorTools, t)
+		}
+	}
+	return nonVectorTools
+}
+
 // getAllToolsDefs returns all available tools with their specs and handlers
 func (s *Neo4jMCPServer) getAllToolsDefs(deps *tools.ToolDependencies) []ToolDefinition {
 
@@ -137,6 +157,15 @@ func (s *Neo4jMCPServer) getAllToolsDefs(deps *tools.ToolDependencies) []ToolDef
 			definition: server.ServerTool{
 				Tool:    gds.ListGDSProceduresSpec(),
 				Handler: gds.ListGdsProceduresHandler(deps),
+			},
+			readonly: true,
+		},
+		// Vector Category/Section
+		{
+			category: vectorCategory,
+			definition: server.ServerTool{
+				Tool:    vector.SearchSpec(),
+				Handler: vector.SearchHandler(deps, s.config.EmbeddingConfig(), s.useSearchClause.Load, s.useAiTextEmbed.Load),
 			},
 			readonly: true,
 		},

--- a/internal/tools/vector/embedding.go
+++ b/internal/tools/vector/embedding.go
@@ -1,0 +1,250 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+package vector
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/neo4j/mcp/internal/config"
+)
+
+// BuildEmbedConfig builds the configuration map for the ai.text.embed Cypher function.
+// It returns the provider string, the configuration map, and any validation error.
+// The configuration map is passed as a bound Cypher parameter ($embedConfig) and
+// never interpolated into query text, keeping the API key safe.
+func BuildEmbedConfig(emb config.EmbeddingConfig) (provider string, cfg map[string]any, err error) {
+	switch emb.Provider {
+	case config.EmbeddingProviderOpenAI:
+		if emb.APIKey == "" {
+			return "", nil, fmt.Errorf("embedding API key is required for provider '%s'", emb.Provider)
+		}
+		if emb.Model == "" {
+			return "", nil, fmt.Errorf("embedding model is required for provider '%s'", emb.Provider)
+		}
+		m := map[string]any{
+			"token": emb.APIKey,
+			"model": emb.Model,
+		}
+		if emb.Dimensions != "" {
+			dims, err := parseDimensions(emb.Dimensions)
+			if err != nil {
+				return "", nil, err
+			}
+			m["vendorOptions"] = map[string]any{"dimensions": dims}
+		}
+		return emb.Provider, m, nil
+
+	case config.EmbeddingProviderAzureOpenAI:
+		if emb.APIKey == "" {
+			return "", nil, fmt.Errorf("embedding API key is required for provider '%s'", emb.Provider)
+		}
+		if emb.Model == "" {
+			return "", nil, fmt.Errorf("embedding model is required for provider '%s'", emb.Provider)
+		}
+		if emb.AzureResource == "" {
+			return "", nil, fmt.Errorf("resource name is required for provider '%s'", emb.Provider)
+		}
+		m := map[string]any{
+			"token":    emb.APIKey,
+			"resource": emb.AzureResource,
+			"model":    emb.Model,
+		}
+		if emb.Dimensions != "" {
+			dims, err := parseDimensions(emb.Dimensions)
+			if err != nil {
+				return "", nil, err
+			}
+			m["vendorOptions"] = map[string]any{"dimensions": dims}
+		}
+		return emb.Provider, m, nil
+
+	case config.EmbeddingProviderVertexAI:
+		if emb.APIKey == "" {
+			return "", nil, fmt.Errorf("embedding API key (token) is required for provider '%s'", emb.Provider)
+		}
+		if emb.Model == "" {
+			return "", nil, fmt.Errorf("embedding model is required for provider '%s'", emb.Provider)
+		}
+		if emb.VertexProject == "" {
+			return "", nil, fmt.Errorf("project is required for provider '%s'", emb.Provider)
+		}
+		if emb.VertexRegion == "" {
+			return "", nil, fmt.Errorf("region is required for provider '%s'", emb.Provider)
+		}
+		publisher := emb.VertexPublisher
+		if publisher == "" {
+			publisher = "google"
+		}
+		m := map[string]any{
+			"token":     emb.APIKey,
+			"model":     emb.Model,
+			"project":   emb.VertexProject,
+			"region":    emb.VertexRegion,
+			"publisher": publisher,
+		}
+		if emb.Dimensions != "" {
+			dims, err := parseDimensions(emb.Dimensions)
+			if err != nil {
+				return "", nil, err
+			}
+			m["vendorOptions"] = map[string]any{"outputDimensionality": dims}
+		}
+		return emb.Provider, m, nil
+
+	case config.EmbeddingProviderBedrockTitan:
+		if emb.AWSAccessKeyID == "" {
+			return "", nil, fmt.Errorf("AWS access key ID is required for provider '%s'", emb.Provider)
+		}
+		if emb.AWSSecretAccessKey == "" {
+			return "", nil, fmt.Errorf("AWS secret access key is required for provider '%s'", emb.Provider)
+		}
+		if emb.Model == "" {
+			return "", nil, fmt.Errorf("embedding model is required for provider '%s'", emb.Provider)
+		}
+		if emb.AWSRegion == "" {
+			return "", nil, fmt.Errorf("AWS region is required for provider '%s'", emb.Provider)
+		}
+		m := map[string]any{
+			"accessKeyId":     emb.AWSAccessKeyID,
+			"secretAccessKey": emb.AWSSecretAccessKey,
+			"model":           emb.Model,
+			"region":          emb.AWSRegion,
+		}
+		if emb.Dimensions != "" {
+			dims, err := parseDimensions(emb.Dimensions)
+			if err != nil {
+				return "", nil, err
+			}
+			m["vendorOptions"] = map[string]any{"dimensions": dims}
+		}
+		return emb.Provider, m, nil
+
+	case "":
+		return "", nil, fmt.Errorf("embedding provider is not configured")
+
+	default:
+		return "", nil, fmt.Errorf("unknown embedding provider '%s'; must be one of: openai, azure-openai, vertexai, bedrock-titan", emb.Provider)
+	}
+}
+
+// genaiProviderOpenAI, genaiProviderAzureOpenAI, genaiProviderVertexAI, and
+// genaiProviderBedrock are the provider literals expected by the (deprecated but still
+// present on Neo4j 5.x / 2025.01–2025.10, incl. current Aura 5.x) genai.vector.encode
+// Cypher function. Unlike ai.text.embed, genai.vector.encode uses PascalCase provider
+// names rather than the lowercase-hyphen names in config.EmbeddingConfig.Provider.
+const (
+	genaiProviderOpenAI      = "OpenAI"
+	genaiProviderAzureOpenAI = "AzureOpenAI"
+	genaiProviderVertexAI    = "VertexAI"
+	genaiProviderBedrock     = "Bedrock"
+)
+
+// BuildGenaiVectorEncodeConfig builds the configuration map for the genai.vector.encode
+// Cypher function — the fallback embedding function for Neo4j versions older than
+// 2025.11 (e.g. 5.x, current Aura 5.x), which do not have ai.text.embed. It returns the
+// PascalCase provider literal expected by genai.vector.encode, the configuration map,
+// and any validation error. As with BuildEmbedConfig, the configuration map is passed as
+// a bound Cypher parameter ($embedConfig) and never interpolated into query text, keeping
+// the API key safe. Unlike BuildEmbedConfig, dimensions are a flat "dimensions" key
+// rather than nested under "vendorOptions".
+func BuildGenaiVectorEncodeConfig(emb config.EmbeddingConfig) (provider string, cfg map[string]any, err error) {
+	switch emb.Provider {
+	case config.EmbeddingProviderOpenAI:
+		if emb.APIKey == "" {
+			return "", nil, fmt.Errorf("embedding API key is required for provider '%s'", emb.Provider)
+		}
+		m := map[string]any{
+			"token": emb.APIKey,
+		}
+		if emb.Model != "" {
+			m["model"] = emb.Model
+		}
+		if emb.Dimensions != "" {
+			dims, err := parseDimensions(emb.Dimensions)
+			if err != nil {
+				return "", nil, err
+			}
+			m["dimensions"] = dims
+		}
+		return genaiProviderOpenAI, m, nil
+
+	case config.EmbeddingProviderAzureOpenAI:
+		if emb.APIKey == "" {
+			return "", nil, fmt.Errorf("embedding API key is required for provider '%s'", emb.Provider)
+		}
+		if emb.AzureResource == "" {
+			return "", nil, fmt.Errorf("resource name is required for provider '%s'", emb.Provider)
+		}
+		if emb.Model == "" {
+			return "", nil, fmt.Errorf("embedding model is required for provider '%s'", emb.Provider)
+		}
+		m := map[string]any{
+			"token":      emb.APIKey,
+			"resource":   emb.AzureResource,
+			"deployment": emb.Model,
+		}
+		if emb.Dimensions != "" {
+			dims, err := parseDimensions(emb.Dimensions)
+			if err != nil {
+				return "", nil, err
+			}
+			m["dimensions"] = dims
+		}
+		return genaiProviderAzureOpenAI, m, nil
+
+	case config.EmbeddingProviderVertexAI:
+		if emb.APIKey == "" {
+			return "", nil, fmt.Errorf("embedding API key (token) is required for provider '%s'", emb.Provider)
+		}
+		if emb.VertexProject == "" {
+			return "", nil, fmt.Errorf("project is required for provider '%s'", emb.Provider)
+		}
+		m := map[string]any{
+			"token":     emb.APIKey,
+			"projectId": emb.VertexProject,
+		}
+		if emb.Model != "" {
+			m["model"] = emb.Model
+		}
+		if emb.VertexRegion != "" {
+			m["region"] = emb.VertexRegion
+		}
+		return genaiProviderVertexAI, m, nil
+
+	case config.EmbeddingProviderBedrockTitan:
+		if emb.AWSAccessKeyID == "" {
+			return "", nil, fmt.Errorf("AWS access key ID is required for provider '%s'", emb.Provider)
+		}
+		if emb.AWSSecretAccessKey == "" {
+			return "", nil, fmt.Errorf("AWS secret access key is required for provider '%s'", emb.Provider)
+		}
+		m := map[string]any{
+			"accessKeyId":     emb.AWSAccessKeyID,
+			"secretAccessKey": emb.AWSSecretAccessKey,
+		}
+		if emb.Model != "" {
+			m["model"] = emb.Model
+		}
+		if emb.AWSRegion != "" {
+			m["region"] = emb.AWSRegion
+		}
+		return genaiProviderBedrock, m, nil
+
+	case "":
+		return "", nil, fmt.Errorf("embedding provider is not configured")
+
+	default:
+		return "", nil, fmt.Errorf("unknown embedding provider '%s'; must be one of: openai, azure-openai, vertexai, bedrock-titan", emb.Provider)
+	}
+}
+
+// parseDimensions parses the dimensions string to an int64.
+func parseDimensions(s string) (int64, error) {
+	d, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid embedding dimensions value '%s': must be a positive integer", s)
+	}
+	return d, nil
+}

--- a/internal/tools/vector/embedding_test.go
+++ b/internal/tools/vector/embedding_test.go
@@ -1,0 +1,626 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+package vector_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/neo4j/mcp/internal/config"
+	"github.com/neo4j/mcp/internal/tools/vector"
+)
+
+// testToken is a non-secret placeholder used as the embedding credential in table
+// tests. It is declared as a variable (rather than a string literal in each struct)
+// to avoid gosec G101 false positives on "hardcoded credentials" in test fixtures.
+var testToken = "placeholder-token"
+
+func TestBuildEmbedConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		emb          config.EmbeddingConfig
+		wantErr      bool
+		wantProvider string
+		checkCfg     func(t *testing.T, cfg map[string]any)
+	}{
+		{
+			name: "openai basic",
+			emb: config.EmbeddingConfig{
+				Provider: config.EmbeddingProviderOpenAI,
+				APIKey:   "sk-placeholder",
+				Model:    "text-embedding-3-small",
+			},
+			wantProvider: config.EmbeddingProviderOpenAI,
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				assertStringKey(t, cfg, "token", "sk-placeholder")
+				assertStringKey(t, cfg, "model", "text-embedding-3-small")
+				if _, ok := cfg["vendorOptions"]; ok {
+					t.Error("vendorOptions should be absent when Dimensions is empty")
+				}
+			},
+		},
+		{
+			name: "openai with dimensions",
+			emb: config.EmbeddingConfig{
+				Provider:   config.EmbeddingProviderOpenAI,
+				APIKey:     "sk-placeholder",
+				Model:      "text-embedding-3-small",
+				Dimensions: "1536",
+			},
+			wantProvider: config.EmbeddingProviderOpenAI,
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				vo, ok := cfg["vendorOptions"].(map[string]any)
+				if !ok {
+					t.Fatal("vendorOptions should be present")
+				}
+				if vo["dimensions"] != int64(1536) {
+					t.Errorf("expected dimensions=1536, got %v", vo["dimensions"])
+				}
+			},
+		},
+		{
+			name: "openai missing api key",
+			emb: config.EmbeddingConfig{
+				Provider: config.EmbeddingProviderOpenAI,
+				Model:    "text-embedding-3-small",
+			},
+			wantErr: true,
+		},
+		{
+			name: "openai missing model",
+			emb: config.EmbeddingConfig{
+				Provider: config.EmbeddingProviderOpenAI,
+				APIKey:   "sk-placeholder",
+			},
+			wantErr: true,
+		},
+		{
+			name: "azure-openai basic",
+			emb: config.EmbeddingConfig{
+				Provider:      config.EmbeddingProviderAzureOpenAI,
+				APIKey:        "azure-key-placeholder",
+				Model:         "text-embedding-ada-002",
+				AzureResource: "my-azure-resource",
+			},
+			wantProvider: config.EmbeddingProviderAzureOpenAI,
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				assertStringKey(t, cfg, "token", "azure-key-placeholder")
+				assertStringKey(t, cfg, "resource", "my-azure-resource")
+				assertStringKey(t, cfg, "model", "text-embedding-ada-002")
+			},
+		},
+		{
+			name: "azure-openai with dimensions",
+			emb: config.EmbeddingConfig{
+				Provider:      config.EmbeddingProviderAzureOpenAI,
+				APIKey:        "azure-key-placeholder",
+				Model:         "text-embedding-ada-002",
+				AzureResource: "my-azure-resource",
+				Dimensions:    "256",
+			},
+			wantProvider: config.EmbeddingProviderAzureOpenAI,
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				vo, ok := cfg["vendorOptions"].(map[string]any)
+				if !ok {
+					t.Fatal("vendorOptions should be present")
+				}
+				if vo["dimensions"] != int64(256) {
+					t.Errorf("expected dimensions=256, got %v", vo["dimensions"])
+				}
+			},
+		},
+		{
+			name: "azure-openai missing resource",
+			emb: config.EmbeddingConfig{
+				Provider: config.EmbeddingProviderAzureOpenAI,
+				APIKey:   "azure-key-placeholder",
+				Model:    "text-embedding-ada-002",
+			},
+			wantErr: true,
+		},
+		{
+			name: "vertexai basic",
+			emb: config.EmbeddingConfig{
+				Provider:      config.EmbeddingProviderVertexAI,
+				APIKey:        testToken,
+				Model:         "textembedding-gecko",
+				VertexProject: "my-project",
+				VertexRegion:  "us-central1",
+			},
+			wantProvider: config.EmbeddingProviderVertexAI,
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				assertStringKey(t, cfg, "token", testToken)
+				assertStringKey(t, cfg, "model", "textembedding-gecko")
+				assertStringKey(t, cfg, "project", "my-project")
+				assertStringKey(t, cfg, "region", "us-central1")
+				// default publisher should be "google"
+				assertStringKey(t, cfg, "publisher", "google")
+			},
+		},
+		{
+			name: "vertexai with explicit publisher",
+			emb: config.EmbeddingConfig{
+				Provider:        config.EmbeddingProviderVertexAI,
+				APIKey:          testToken,
+				Model:           "textembedding-gecko",
+				VertexProject:   "my-project",
+				VertexRegion:    "us-central1",
+				VertexPublisher: "anthropic",
+			},
+			wantProvider: config.EmbeddingProviderVertexAI,
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				assertStringKey(t, cfg, "publisher", "anthropic")
+			},
+		},
+		{
+			name: "vertexai with outputDimensionality",
+			emb: config.EmbeddingConfig{
+				Provider:      config.EmbeddingProviderVertexAI,
+				APIKey:        testToken,
+				Model:         "textembedding-gecko",
+				VertexProject: "my-project",
+				VertexRegion:  "us-central1",
+				Dimensions:    "768",
+			},
+			wantProvider: config.EmbeddingProviderVertexAI,
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				vo, ok := cfg["vendorOptions"].(map[string]any)
+				if !ok {
+					t.Fatal("vendorOptions should be present")
+				}
+				if vo["outputDimensionality"] != int64(768) {
+					t.Errorf("expected outputDimensionality=768, got %v", vo["outputDimensionality"])
+				}
+			},
+		},
+		{
+			name: "vertexai missing project",
+			emb: config.EmbeddingConfig{
+				Provider:     config.EmbeddingProviderVertexAI,
+				APIKey:       testToken,
+				Model:        "textembedding-gecko",
+				VertexRegion: "us-central1",
+			},
+			wantErr: true,
+		},
+		{
+			name: "bedrock-titan basic",
+			emb: config.EmbeddingConfig{
+				Provider:           config.EmbeddingProviderBedrockTitan,
+				AWSAccessKeyID:     "test-access-key-id",
+				AWSSecretAccessKey: "test-secret-access-key",
+				Model:              "amazon.titan-embed-text-v1",
+				AWSRegion:          "us-east-1",
+			},
+			wantProvider: config.EmbeddingProviderBedrockTitan,
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				assertStringKey(t, cfg, "accessKeyId", "test-access-key-id")
+				assertStringKey(t, cfg, "secretAccessKey", "test-secret-access-key")
+				assertStringKey(t, cfg, "model", "amazon.titan-embed-text-v1")
+				assertStringKey(t, cfg, "region", "us-east-1")
+			},
+		},
+		{
+			name: "bedrock-titan with dimensions",
+			emb: config.EmbeddingConfig{
+				Provider:           config.EmbeddingProviderBedrockTitan,
+				AWSAccessKeyID:     "test-access-key-id",
+				AWSSecretAccessKey: "test-secret-access-key",
+				Model:              "amazon.titan-embed-text-v1",
+				AWSRegion:          "us-east-1",
+				Dimensions:         "512",
+			},
+			wantProvider: config.EmbeddingProviderBedrockTitan,
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				vo, ok := cfg["vendorOptions"].(map[string]any)
+				if !ok {
+					t.Fatal("vendorOptions should be present")
+				}
+				if vo["dimensions"] != int64(512) {
+					t.Errorf("expected dimensions=512, got %v", vo["dimensions"])
+				}
+			},
+		},
+		{
+			name: "bedrock-titan missing access key",
+			emb: config.EmbeddingConfig{
+				Provider:           config.EmbeddingProviderBedrockTitan,
+				AWSSecretAccessKey: "secret-placeholder",
+				Model:              "amazon.titan-embed-text-v1",
+				AWSRegion:          "us-east-1",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty provider",
+			emb: config.EmbeddingConfig{
+				Provider: "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown provider",
+			emb: config.EmbeddingConfig{
+				Provider: "llama-local",
+			},
+			wantErr: true,
+		},
+		{
+			name: "dimensions non-numeric",
+			emb: config.EmbeddingConfig{
+				Provider:   config.EmbeddingProviderOpenAI,
+				APIKey:     "sk-placeholder",
+				Model:      "text-embedding-3-small",
+				Dimensions: "not-a-number",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			provider, cfg, err := vector.BuildEmbedConfig(tc.emb)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil (provider=%s, cfg=%v)", provider, cfg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if provider != tc.wantProvider {
+				t.Errorf("provider: want %q, got %q", tc.wantProvider, provider)
+			}
+			if tc.checkCfg != nil {
+				tc.checkCfg(t, cfg)
+			}
+		})
+	}
+}
+
+func TestBuildGenaiVectorEncodeConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		emb          config.EmbeddingConfig
+		wantErr      bool
+		wantProvider string
+		checkCfg     func(t *testing.T, cfg map[string]any)
+	}{
+		{
+			name: "openai basic",
+			emb: config.EmbeddingConfig{
+				Provider: config.EmbeddingProviderOpenAI,
+				APIKey:   "sk-placeholder",
+				Model:    "text-embedding-3-small",
+			},
+			wantProvider: "OpenAI",
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				assertStringKey(t, cfg, "token", "sk-placeholder")
+				assertStringKey(t, cfg, "model", "text-embedding-3-small")
+				if _, ok := cfg["dimensions"]; ok {
+					t.Error("dimensions should be absent when Dimensions is empty")
+				}
+				if _, ok := cfg["vendorOptions"]; ok {
+					t.Error("genai.vector.encode config must not use nested vendorOptions")
+				}
+			},
+		},
+		{
+			name: "openai with dimensions is flat, not nested",
+			emb: config.EmbeddingConfig{
+				Provider:   config.EmbeddingProviderOpenAI,
+				APIKey:     "sk-placeholder",
+				Model:      "text-embedding-3-small",
+				Dimensions: "1536",
+			},
+			wantProvider: "OpenAI",
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				if cfg["dimensions"] != int64(1536) {
+					t.Errorf("expected flat dimensions=1536, got %v", cfg["dimensions"])
+				}
+			},
+		},
+		{
+			name: "openai model is optional",
+			emb: config.EmbeddingConfig{
+				Provider: config.EmbeddingProviderOpenAI,
+				APIKey:   "sk-placeholder",
+			},
+			wantProvider: "OpenAI",
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				assertStringKey(t, cfg, "token", "sk-placeholder")
+				if _, ok := cfg["model"]; ok {
+					t.Error("model should be absent when not set")
+				}
+			},
+		},
+		{
+			name: "openai missing token",
+			emb: config.EmbeddingConfig{
+				Provider: config.EmbeddingProviderOpenAI,
+				Model:    "text-embedding-3-small",
+			},
+			wantErr: true,
+		},
+		{
+			name: "azure-openai basic maps model to deployment",
+			emb: config.EmbeddingConfig{
+				Provider:      config.EmbeddingProviderAzureOpenAI,
+				APIKey:        "azure-key-placeholder",
+				Model:         "text-embedding-ada-002",
+				AzureResource: "my-azure-resource",
+			},
+			wantProvider: "AzureOpenAI",
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				assertStringKey(t, cfg, "token", "azure-key-placeholder")
+				assertStringKey(t, cfg, "resource", "my-azure-resource")
+				assertStringKey(t, cfg, "deployment", "text-embedding-ada-002")
+				if _, ok := cfg["model"]; ok {
+					t.Error("genai.vector.encode azure config must use 'deployment', not 'model'")
+				}
+			},
+		},
+		{
+			name: "azure-openai with dimensions is flat",
+			emb: config.EmbeddingConfig{
+				Provider:      config.EmbeddingProviderAzureOpenAI,
+				APIKey:        "azure-key-placeholder",
+				Model:         "text-embedding-ada-002",
+				AzureResource: "my-azure-resource",
+				Dimensions:    "256",
+			},
+			wantProvider: "AzureOpenAI",
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				if cfg["dimensions"] != int64(256) {
+					t.Errorf("expected flat dimensions=256, got %v", cfg["dimensions"])
+				}
+			},
+		},
+		{
+			name: "azure-openai missing resource",
+			emb: config.EmbeddingConfig{
+				Provider: config.EmbeddingProviderAzureOpenAI,
+				APIKey:   "azure-key-placeholder",
+				Model:    "text-embedding-ada-002",
+			},
+			wantErr: true,
+		},
+		{
+			name: "azure-openai missing deployment (model)",
+			emb: config.EmbeddingConfig{
+				Provider:      config.EmbeddingProviderAzureOpenAI,
+				APIKey:        "azure-key-placeholder",
+				AzureResource: "my-azure-resource",
+			},
+			wantErr: true,
+		},
+		{
+			name: "vertexai basic uses projectId not project, no publisher",
+			emb: config.EmbeddingConfig{
+				Provider:      config.EmbeddingProviderVertexAI,
+				APIKey:        testToken,
+				Model:         "textembedding-gecko",
+				VertexProject: "my-project",
+				VertexRegion:  "us-central1",
+			},
+			wantProvider: "VertexAI",
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				assertStringKey(t, cfg, "token", testToken)
+				assertStringKey(t, cfg, "model", "textembedding-gecko")
+				assertStringKey(t, cfg, "projectId", "my-project")
+				assertStringKey(t, cfg, "region", "us-central1")
+				if _, ok := cfg["project"]; ok {
+					t.Error("genai.vector.encode vertex config must use 'projectId', not 'project'")
+				}
+				if _, ok := cfg["publisher"]; ok {
+					t.Error("genai.vector.encode vertex config must not include 'publisher'")
+				}
+			},
+		},
+		{
+			name: "vertexai model and region are optional",
+			emb: config.EmbeddingConfig{
+				Provider:      config.EmbeddingProviderVertexAI,
+				APIKey:        testToken,
+				VertexProject: "my-project",
+			},
+			wantProvider: "VertexAI",
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				assertStringKey(t, cfg, "projectId", "my-project")
+				if _, ok := cfg["model"]; ok {
+					t.Error("model should be absent when not set")
+				}
+				if _, ok := cfg["region"]; ok {
+					t.Error("region should be absent when not set")
+				}
+			},
+		},
+		{
+			name: "vertexai missing token",
+			emb: config.EmbeddingConfig{
+				Provider:      config.EmbeddingProviderVertexAI,
+				VertexProject: "my-project",
+				VertexRegion:  "us-central1",
+			},
+			wantErr: true,
+		},
+		{
+			name: "vertexai missing projectId",
+			emb: config.EmbeddingConfig{
+				Provider:     config.EmbeddingProviderVertexAI,
+				APIKey:       testToken,
+				VertexRegion: "us-central1",
+			},
+			wantErr: true,
+		},
+		{
+			name: "bedrock-titan basic",
+			emb: config.EmbeddingConfig{
+				Provider:           config.EmbeddingProviderBedrockTitan,
+				AWSAccessKeyID:     "test-access-key-id",
+				AWSSecretAccessKey: "test-secret-access-key",
+				Model:              "amazon.titan-embed-text-v1",
+				AWSRegion:          "us-east-1",
+			},
+			wantProvider: "Bedrock",
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				assertStringKey(t, cfg, "accessKeyId", "test-access-key-id")
+				assertStringKey(t, cfg, "secretAccessKey", "test-secret-access-key")
+				assertStringKey(t, cfg, "model", "amazon.titan-embed-text-v1")
+				assertStringKey(t, cfg, "region", "us-east-1")
+			},
+		},
+		{
+			name: "bedrock-titan model and region are optional",
+			emb: config.EmbeddingConfig{
+				Provider:           config.EmbeddingProviderBedrockTitan,
+				AWSAccessKeyID:     "test-access-key-id",
+				AWSSecretAccessKey: "test-secret-access-key",
+			},
+			wantProvider: "Bedrock",
+			checkCfg: func(t *testing.T, cfg map[string]any) {
+				t.Helper()
+				if _, ok := cfg["model"]; ok {
+					t.Error("model should be absent when not set")
+				}
+				if _, ok := cfg["region"]; ok {
+					t.Error("region should be absent when not set")
+				}
+			},
+		},
+		{
+			name: "bedrock-titan missing access key",
+			emb: config.EmbeddingConfig{
+				Provider:           config.EmbeddingProviderBedrockTitan,
+				AWSSecretAccessKey: "secret-placeholder",
+			},
+			wantErr: true,
+		},
+		{
+			name: "bedrock-titan missing secret",
+			emb: config.EmbeddingConfig{
+				Provider:       config.EmbeddingProviderBedrockTitan,
+				AWSAccessKeyID: "test-access-key-id",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty provider",
+			emb: config.EmbeddingConfig{
+				Provider: "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown provider",
+			emb: config.EmbeddingConfig{
+				Provider: "llama-local",
+			},
+			wantErr: true,
+		},
+		{
+			name: "dimensions non-numeric",
+			emb: config.EmbeddingConfig{
+				Provider:   config.EmbeddingProviderOpenAI,
+				APIKey:     "sk-placeholder",
+				Dimensions: "not-a-number",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			provider, cfg, err := vector.BuildGenaiVectorEncodeConfig(tc.emb)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil (provider=%s, cfg=%v)", provider, cfg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if provider != tc.wantProvider {
+				t.Errorf("provider: want %q, got %q", tc.wantProvider, provider)
+			}
+			if tc.checkCfg != nil {
+				tc.checkCfg(t, cfg)
+			}
+		})
+	}
+}
+
+// TestBuildGenaiVectorEncodeConfig_SecretsNotInQueryText is a security regression test:
+// the token/secret values must only ever appear in the returned config map (a bound
+// Cypher parameter), never embedded in any query string the caller might build.
+func TestBuildGenaiVectorEncodeConfig_SecretsNotInQueryText(t *testing.T) {
+	t.Parallel()
+	sensitiveToken := "sk-super-secret-should-never-be-in-query-text"
+	emb := config.EmbeddingConfig{
+		Provider: config.EmbeddingProviderOpenAI,
+		APIKey:   sensitiveToken,
+		Model:    "text-embedding-3-small",
+	}
+
+	provider, cfg, err := vector.BuildGenaiVectorEncodeConfig(emb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The secret must be present in the returned map (it is passed as a bound param)...
+	if cfg["token"] != sensitiveToken {
+		t.Fatalf("expected token in config map, got %v", cfg["token"])
+	}
+	// ...but the query the caller assembles never contains provider/config literals: only
+	// the bound parameter names $provider and $embedConfig appear in BuildVectorQuery's
+	// output, which is exercised separately in query_builder_test.go. Here we assert the
+	// provider literal itself carries no secret material.
+	if strings.Contains(provider, sensitiveToken) {
+		t.Fatalf("provider literal must not contain secret material: %q", provider)
+	}
+}
+
+func assertStringKey(t *testing.T, m map[string]any, key, want string) {
+	t.Helper()
+	v, ok := m[key]
+	if !ok {
+		t.Errorf("key %q not found in config map", key)
+		return
+	}
+	s, ok := v.(string)
+	if !ok {
+		t.Errorf("key %q: expected string, got %T", key, v)
+		return
+	}
+	if s != want {
+		t.Errorf("key %q: want %q, got %q", key, want, s)
+	}
+}

--- a/internal/tools/vector/index_resolver.go
+++ b/internal/tools/vector/index_resolver.go
@@ -1,0 +1,160 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+package vector
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/neo4j/mcp/internal/database"
+)
+
+const showVectorIndexesQuery = `SHOW VECTOR INDEXES YIELD name, entityType, labelsOrTypes, properties, options RETURN name, entityType, labelsOrTypes, properties, options`
+
+// rawIndexEntry is a helper used only within ResolveIndex.
+type rawIndexEntry struct {
+	name       string
+	entityType string
+	label      string
+	embProp    string
+	dimensions int64
+}
+
+// ResolveIndex resolves a vector index by name (or auto-selects if only one exists).
+// It queries SHOW VECTOR INDEXES and returns full metadata about the resolved index.
+func ResolveIndex(ctx context.Context, db database.Service, indexName string) (*ResolvedIndex, error) {
+	records, err := db.ExecuteReadQuery(ctx, showVectorIndexesQuery, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list vector indexes: %w", err)
+	}
+
+	var all []rawIndexEntry
+	for _, rec := range records {
+		nameRaw, ok := rec.Get("name")
+		if !ok {
+			continue
+		}
+		name, ok := nameRaw.(string)
+		if !ok {
+			continue
+		}
+
+		entityTypeRaw, ok := rec.Get("entityType")
+		if !ok {
+			continue
+		}
+		entityType, ok := entityTypeRaw.(string)
+		if !ok {
+			continue
+		}
+
+		labelsRaw, ok := rec.Get("labelsOrTypes")
+		if !ok {
+			continue
+		}
+		labels, ok := labelsRaw.([]any)
+		if !ok || len(labels) == 0 {
+			continue
+		}
+		label, ok := labels[0].(string)
+		if !ok {
+			continue
+		}
+
+		propsRaw, ok := rec.Get("properties")
+		if !ok {
+			continue
+		}
+		props, ok := propsRaw.([]any)
+		if !ok || len(props) == 0 {
+			continue
+		}
+		embProp, ok := props[0].(string)
+		if !ok {
+			continue
+		}
+
+		var dims int64
+		optionsRaw, ok := rec.Get("options")
+		if ok && optionsRaw != nil {
+			if optMap, ok := optionsRaw.(map[string]any); ok {
+				if idxCfgRaw, ok := optMap["indexConfig"]; ok {
+					if idxCfg, ok := idxCfgRaw.(map[string]any); ok {
+						if dimRaw, ok := idxCfg["vector.dimensions"]; ok {
+							switch v := dimRaw.(type) {
+							case int64:
+								dims = v
+							case float64:
+								dims = int64(v)
+							}
+						}
+					}
+				}
+			}
+		}
+
+		all = append(all, rawIndexEntry{
+			name:       name,
+			entityType: entityType,
+			label:      label,
+			embProp:    embProp,
+			dimensions: dims,
+		})
+	}
+
+	var selected *rawIndexEntry
+
+	if indexName != "" {
+		for i := range all {
+			if all[i].name == indexName {
+				selected = &all[i]
+				break
+			}
+		}
+		if selected == nil {
+			available := collectNames(all)
+			if len(available) == 0 {
+				return nil, fmt.Errorf("vector index '%s' not found; no vector indexes exist in the database", indexName)
+			}
+			return nil, fmt.Errorf("vector index '%s' not found; available vector indexes: %s", indexName, strings.Join(available, ", "))
+		}
+	} else {
+		switch len(all) {
+		case 0:
+			return nil, fmt.Errorf("no vector index found in the database")
+		case 1:
+			selected = &all[0]
+		default:
+			return nil, fmt.Errorf("multiple vector indexes found (%s); specify indexName to disambiguate", strings.Join(collectNames(all), ", "))
+		}
+	}
+
+	return &ResolvedIndex{
+		Name:              selected.name,
+		EntityType:        selected.entityType,
+		Label:             selected.label,
+		EmbeddingProperty: selected.embProp,
+		Dimensions:        selected.dimensions,
+	}, nil
+}
+
+// escapeIdentifier validates that the identifier is non-empty and returns it
+// wrapped in backticks, with any internal backtick characters doubled.
+// This is safe for literal interpolation of index names and labels in Cypher.
+func escapeIdentifier(s string) (string, error) {
+	if s == "" {
+		return "", fmt.Errorf("identifier must not be empty")
+	}
+	escaped := strings.ReplaceAll(s, "`", "``")
+	return "`" + escaped + "`", nil
+}
+
+func collectNames(entries []rawIndexEntry) []string {
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.name
+	}
+	return names
+}

--- a/internal/tools/vector/index_resolver_test.go
+++ b/internal/tools/vector/index_resolver_test.go
@@ -1,0 +1,241 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+package vector_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	db "github.com/neo4j/mcp/internal/database/mocks"
+	"github.com/neo4j/mcp/internal/tools/vector"
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j"
+	"go.uber.org/mock/gomock"
+)
+
+// makeIndexRecord builds a *neo4j.Record that mimics a row from SHOW VECTOR INDEXES.
+func makeIndexRecord(name, entityType, label, embProp string, dims any) *neo4j.Record {
+	optMap := map[string]any{}
+	if dims != nil {
+		optMap["indexConfig"] = map[string]any{
+			"vector.dimensions": dims,
+		}
+	}
+	return &neo4j.Record{
+		Keys: []string{"name", "entityType", "labelsOrTypes", "properties", "options"},
+		Values: []any{
+			name,
+			entityType,
+			[]any{label},
+			[]any{embProp},
+			optMap,
+		},
+	}
+}
+
+func TestResolveIndex_SingleAutoSelect(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := db.NewMockService(ctrl)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return([]*neo4j.Record{
+			makeIndexRecord("moviePlots", "NODE", "Movie", "embedding", int64(1536)),
+		}, nil)
+
+	idx, err := vector.ResolveIndex(context.Background(), mockDB, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if idx.Name != "moviePlots" {
+		t.Errorf("name: want moviePlots, got %s", idx.Name)
+	}
+	if idx.Label != "Movie" {
+		t.Errorf("label: want Movie, got %s", idx.Label)
+	}
+	if idx.EmbeddingProperty != "embedding" {
+		t.Errorf("embProp: want embedding, got %s", idx.EmbeddingProperty)
+	}
+	if idx.EntityType != "NODE" {
+		t.Errorf("entityType: want NODE, got %s", idx.EntityType)
+	}
+	if idx.Dimensions != 1536 {
+		t.Errorf("dimensions: want 1536, got %d", idx.Dimensions)
+	}
+}
+
+func TestResolveIndex_NamedIndex(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := db.NewMockService(ctrl)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return([]*neo4j.Record{
+			makeIndexRecord("moviePlots", "NODE", "Movie", "embedding", int64(1536)),
+			makeIndexRecord("actorBios", "NODE", "Actor", "bio_emb", nil),
+		}, nil)
+
+	idx, err := vector.ResolveIndex(context.Background(), mockDB, "actorBios")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if idx.Name != "actorBios" {
+		t.Errorf("name: want actorBios, got %s", idx.Name)
+	}
+	if idx.Dimensions != 0 {
+		t.Errorf("dimensions: want 0 when absent, got %d", idx.Dimensions)
+	}
+}
+
+func TestResolveIndex_NotFound(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := db.NewMockService(ctrl)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return([]*neo4j.Record{
+			makeIndexRecord("moviePlots", "NODE", "Movie", "embedding", nil),
+		}, nil)
+
+	_, err := vector.ResolveIndex(context.Background(), mockDB, "nonExistentIndex")
+	if err == nil {
+		t.Fatal("expected error for not-found index")
+	}
+	if !strings.Contains(err.Error(), "nonExistentIndex") {
+		t.Errorf("error should mention the missing index name: %v", err)
+	}
+	if !strings.Contains(err.Error(), "moviePlots") {
+		t.Errorf("error should list available indexes: %v", err)
+	}
+}
+
+func TestResolveIndex_Ambiguous(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := db.NewMockService(ctrl)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return([]*neo4j.Record{
+			makeIndexRecord("moviePlots", "NODE", "Movie", "embedding", nil),
+			makeIndexRecord("actorBios", "NODE", "Actor", "bio_emb", nil),
+		}, nil)
+
+	_, err := vector.ResolveIndex(context.Background(), mockDB, "")
+	if err == nil {
+		t.Fatal("expected error when multiple indexes and no name given")
+	}
+	if !strings.Contains(err.Error(), "moviePlots") || !strings.Contains(err.Error(), "actorBios") {
+		t.Errorf("error should list available indexes: %v", err)
+	}
+}
+
+func TestResolveIndex_NoIndexes(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := db.NewMockService(ctrl)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return([]*neo4j.Record{}, nil)
+
+	_, err := vector.ResolveIndex(context.Background(), mockDB, "")
+	if err == nil {
+		t.Fatal("expected error when no indexes")
+	}
+	if !strings.Contains(err.Error(), "no vector index") {
+		t.Errorf("error message mismatch: %v", err)
+	}
+}
+
+func TestResolveIndex_DBError(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := db.NewMockService(ctrl)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return(nil, errors.New("connection refused"))
+
+	_, err := vector.ResolveIndex(context.Background(), mockDB, "")
+	if err == nil {
+		t.Fatal("expected error from DB failure")
+	}
+}
+
+func TestResolveIndex_DimensionsFloat64(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Some versions may return float64 for numeric config values
+	mockDB := db.NewMockService(ctrl)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return([]*neo4j.Record{
+			makeIndexRecord("moviePlots", "NODE", "Movie", "embedding", float64(768)),
+		}, nil)
+
+	idx, err := vector.ResolveIndex(context.Background(), mockDB, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if idx.Dimensions != 768 {
+		t.Errorf("dimensions from float64: want 768, got %d", idx.Dimensions)
+	}
+}
+
+func TestResolveIndex_NotFoundNoAvailable(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Asking for a specific index when none exist
+	mockDB := db.NewMockService(ctrl)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return([]*neo4j.Record{}, nil)
+
+	_, err := vector.ResolveIndex(context.Background(), mockDB, "missingIndex")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "missingIndex") {
+		t.Errorf("error should mention index name: %v", err)
+	}
+}
+
+func TestResolveIndex_RelationshipEntityType(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDB := db.NewMockService(ctrl)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return([]*neo4j.Record{
+			makeIndexRecord("relIdx", "RELATIONSHIP", "ACTED_IN", "plotEmb", nil),
+		}, nil)
+
+	idx, err := vector.ResolveIndex(context.Background(), mockDB, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if idx.EntityType != "RELATIONSHIP" {
+		t.Errorf("entityType: want RELATIONSHIP, got %s", idx.EntityType)
+	}
+	if idx.Label != "ACTED_IN" {
+		t.Errorf("label: want ACTED_IN, got %s", idx.Label)
+	}
+}

--- a/internal/tools/vector/query_builder.go
+++ b/internal/tools/vector/query_builder.go
@@ -1,0 +1,166 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+package vector
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// allowedOperators is the set of operators permitted in filter clauses.
+var allowedOperators = map[string]bool{
+	"=":           true,
+	"<>":          true,
+	"<":           true,
+	"<=":          true,
+	">":           true,
+	">=":          true,
+	"IN":          true,
+	"CONTAINS":    true,
+	"STARTS WITH": true,
+	"ENDS WITH":   true,
+}
+
+// safePropertyName matches identifiers that are safe to use as property names.
+var safePropertyName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// BuildFilterClause builds a Cypher WHERE fragment from a list of filters.
+// The returned fragment does NOT include the "WHERE" keyword — the caller adds it.
+// Property names are validated and backtick-escaped. Values are always bound as
+// parameters ($f0, $f1, ...) to prevent injection.
+// Returns an empty string and nil params when no filters are provided.
+func BuildFilterClause(filters []Filter) (string, map[string]any, error) {
+	if len(filters) == 0 {
+		return "", nil, nil
+	}
+
+	params := make(map[string]any, len(filters))
+	parts := make([]string, 0, len(filters))
+
+	for i, f := range filters {
+		op := strings.ToUpper(strings.TrimSpace(f.Operator))
+		// normalise multi-word operators: collapse internal whitespace
+		op = strings.Join(strings.Fields(op), " ")
+
+		if !allowedOperators[op] {
+			return "", nil, fmt.Errorf("filter operator '%s' is not allowed; permitted operators: =, <>, <, <=, >, >=, IN, CONTAINS, STARTS WITH, ENDS WITH", f.Operator)
+		}
+
+		if !safePropertyName.MatchString(f.Property) {
+			return "", nil, fmt.Errorf("filter property '%s' is not a valid identifier; must match ^[A-Za-z_][A-Za-z0-9_]*$", f.Property)
+		}
+
+		if op == "IN" {
+			// Value must be a slice (any slice type)
+			if !isSlice(f.Value) {
+				return "", nil, fmt.Errorf("filter operator IN requires a list value for property '%s'", f.Property)
+			}
+		}
+
+		paramName := fmt.Sprintf("f%d", i)
+		params[paramName] = f.Value
+
+		escapedProp := "`" + strings.ReplaceAll(f.Property, "`", "``") + "`"
+		parts = append(parts, fmt.Sprintf("node.%s %s $%s", escapedProp, op, paramName))
+	}
+
+	return strings.Join(parts, " AND "), params, nil
+}
+
+// BuildVectorQuery builds the Cypher query for vector search.
+//
+//   - idx: resolved index metadata
+//   - useSearchClause: true → SEARCH clause (Neo4j ≥ 2026.01); false → db.index.vector.queryNodes
+//   - useAiTextEmbed: true → embed via ai.text.embed (Neo4j ≥ 2025.11); false → embed via
+//     the deprecated-but-present genai.vector.encode fallback (5.x, 2025.01–2025.10, incl.
+//     current Aura 5.x).
+//   - filterClause: pre-built WHERE fragment from BuildFilterClause (without the "WHERE" keyword);
+//     empty string → no WHERE clause added.
+//
+// The caller is responsible for merging the filter params from BuildFilterClause into
+// the overall query params map.
+func BuildVectorQuery(idx *ResolvedIndex, useSearchClause bool, useAiTextEmbed bool, filterClause string) (string, error) {
+	escapedLabel, err := escapeIdentifier(idx.Label)
+	if err != nil {
+		return "", fmt.Errorf("invalid label '%s': %w", idx.Label, err)
+	}
+
+	escapedEmbProp, err := escapeIdentifier(idx.EmbeddingProperty)
+	if err != nil {
+		return "", fmt.Errorf("invalid embedding property '%s': %w", idx.EmbeddingProperty, err)
+	}
+
+	whereClause := ""
+	if filterClause != "" {
+		whereClause = "\nWHERE " + filterClause
+	}
+
+	embedFn := "genai.vector.encode"
+	if useAiTextEmbed {
+		embedFn = "ai.text.embed"
+	}
+
+	if useSearchClause {
+		escapedIndexName, err := escapeIdentifier(idx.Name)
+		if err != nil {
+			return "", fmt.Errorf("invalid index name '%s': %w", idx.Name, err)
+		}
+
+		var matchLine string
+		if idx.EntityType == "RELATIONSHIP" {
+			matchLine = fmt.Sprintf("MATCH ()-[node:%s]->()", escapedLabel)
+		} else {
+			matchLine = fmt.Sprintf("MATCH (node:%s)", escapedLabel)
+		}
+
+		query := fmt.Sprintf(
+			"WITH %s($query, $provider, $embedConfig) AS qv\n"+
+				"%s\n"+
+				"  SEARCH node IN (VECTOR INDEX %s FOR qv LIMIT $fetchK) SCORE AS score%s\n"+
+				"RETURN node { .*, %s: null } AS node, score\n"+
+				"ORDER BY score DESC\n"+
+				"LIMIT $topK",
+			embedFn,
+			matchLine,
+			escapedIndexName,
+			whereClause,
+			escapedEmbProp,
+		)
+		return query, nil
+	}
+
+	// queryNodes / queryRelationships fallback path
+	var callLine string
+	if idx.EntityType == "RELATIONSHIP" {
+		callLine = "CALL db.index.vector.queryRelationships($indexName, $fetchK, qv) YIELD relationship AS node, score"
+	} else {
+		callLine = "CALL db.index.vector.queryNodes($indexName, $fetchK, qv) YIELD node, score"
+	}
+
+	query := fmt.Sprintf(
+		"WITH %s($query, $provider, $embedConfig) AS qv\n"+
+			"%s%s\n"+
+			"RETURN node { .*, %s: null } AS node, score\n"+
+			"ORDER BY score DESC\n"+
+			"LIMIT $topK",
+		embedFn,
+		callLine,
+		whereClause,
+		escapedEmbProp,
+	)
+	return query, nil
+}
+
+// isSlice returns true if v is any slice type (reflects on the interface value).
+func isSlice(v any) bool {
+	if v == nil {
+		return false
+	}
+	switch v.(type) {
+	case []any, []string, []int, []int64, []float64, []bool:
+		return true
+	}
+	return false
+}

--- a/internal/tools/vector/query_builder_test.go
+++ b/internal/tools/vector/query_builder_test.go
@@ -1,0 +1,326 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+package vector_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/neo4j/mcp/internal/tools/vector"
+)
+
+// makeIdx is a test helper that builds a ResolvedIndex from simple fields.
+func makeIdx(name, entityType, label, embProp string) *vector.ResolvedIndex {
+	return &vector.ResolvedIndex{
+		Name:              name,
+		EntityType:        entityType,
+		Label:             label,
+		EmbeddingProperty: embProp,
+	}
+}
+
+func TestBuildVectorQuery_SearchClause_Node(t *testing.T) {
+	t.Parallel()
+	idx := makeIdx("moviePlots", "NODE", "Movie", "embedding")
+	q, err := vector.BuildVectorQuery(idx, true, true, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContains(t, q, "ai.text.embed($query, $provider, $embedConfig) AS qv")
+	assertContains(t, q, "MATCH (node:`Movie`)")
+	assertContains(t, q, "SEARCH node IN (VECTOR INDEX `moviePlots` FOR qv LIMIT $fetchK) SCORE AS score")
+	assertContains(t, q, "RETURN node { .*, `embedding`: null } AS node, score")
+	assertContains(t, q, "ORDER BY score DESC")
+	assertContains(t, q, "LIMIT $topK")
+	assertNotContains(t, q, "WHERE")
+}
+
+func TestBuildVectorQuery_SearchClause_Node_WithFilters(t *testing.T) {
+	t.Parallel()
+	idx := makeIdx("moviePlots", "NODE", "Movie", "embedding")
+	q, err := vector.BuildVectorQuery(idx, true, true, "node.`genre` = $f0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContains(t, q, "WHERE node.`genre` = $f0")
+}
+
+func TestBuildVectorQuery_SearchClause_Relationship(t *testing.T) {
+	t.Parallel()
+	idx := makeIdx("actedInIdx", "RELATIONSHIP", "ACTED_IN", "plotEmbedding")
+	q, err := vector.BuildVectorQuery(idx, true, true, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContains(t, q, "MATCH ()-[node:`ACTED_IN`]->()")
+	assertContains(t, q, "VECTOR INDEX `actedInIdx`")
+	assertContains(t, q, "`plotEmbedding`: null")
+}
+
+func TestBuildVectorQuery_QueryNodes_Node(t *testing.T) {
+	t.Parallel()
+	idx := makeIdx("moviePlots", "NODE", "Movie", "embedding")
+	q, err := vector.BuildVectorQuery(idx, false, true, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContains(t, q, "CALL db.index.vector.queryNodes($indexName, $fetchK, qv) YIELD node, score")
+	assertContains(t, q, "RETURN node { .*, `embedding`: null } AS node, score")
+	assertNotContains(t, q, "SEARCH node IN")
+	assertNotContains(t, q, "WHERE")
+}
+
+func TestBuildVectorQuery_QueryNodes_Node_WithFilters(t *testing.T) {
+	t.Parallel()
+	idx := makeIdx("moviePlots", "NODE", "Movie", "embedding")
+	q, err := vector.BuildVectorQuery(idx, false, true, "node.`year` >= $f0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContains(t, q, "WHERE node.`year` >= $f0")
+}
+
+func TestBuildVectorQuery_QueryNodes_Relationship(t *testing.T) {
+	t.Parallel()
+	idx := makeIdx("actedInIdx", "RELATIONSHIP", "ACTED_IN", "plotEmbedding")
+	q, err := vector.BuildVectorQuery(idx, false, true, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContains(t, q, "CALL db.index.vector.queryRelationships($indexName, $fetchK, qv) YIELD relationship AS node, score")
+}
+
+func TestBuildVectorQuery_BacktickEscaping(t *testing.T) {
+	t.Parallel()
+	// Index name and label containing backticks should be doubled
+	idx := makeIdx("my`index", "NODE", "My`Label", "emb`Prop")
+	q, err := vector.BuildVectorQuery(idx, true, true, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContains(t, q, "`my``index`")
+	assertContains(t, q, "`My``Label`")
+	assertContains(t, q, "`emb``Prop`: null")
+}
+
+func TestBuildVectorQuery_UseAiTextEmbed_SearchClause(t *testing.T) {
+	t.Parallel()
+	idx := makeIdx("moviePlots", "NODE", "Movie", "embedding")
+
+	qTrue, err := vector.BuildVectorQuery(idx, true, true, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContains(t, qTrue, "ai.text.embed($query, $provider, $embedConfig) AS qv")
+	assertNotContains(t, qTrue, "genai.vector.encode")
+
+	qFalse, err := vector.BuildVectorQuery(idx, true, false, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContains(t, qFalse, "genai.vector.encode($query, $provider, $embedConfig) AS qv")
+	assertNotContains(t, qFalse, "ai.text.embed")
+}
+
+func TestBuildVectorQuery_UseAiTextEmbed_QueryNodes(t *testing.T) {
+	t.Parallel()
+	idx := makeIdx("moviePlots", "NODE", "Movie", "embedding")
+
+	qTrue, err := vector.BuildVectorQuery(idx, false, true, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContains(t, qTrue, "ai.text.embed($query, $provider, $embedConfig) AS qv")
+	assertNotContains(t, qTrue, "genai.vector.encode")
+
+	qFalse, err := vector.BuildVectorQuery(idx, false, false, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContains(t, qFalse, "genai.vector.encode($query, $provider, $embedConfig) AS qv")
+	assertNotContains(t, qFalse, "ai.text.embed")
+}
+
+func TestBuildFilterClause_Empty(t *testing.T) {
+	t.Parallel()
+	clause, params, err := vector.BuildFilterClause(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if clause != "" {
+		t.Errorf("expected empty clause, got %q", clause)
+	}
+	if len(params) != 0 {
+		t.Errorf("expected empty params, got %v", params)
+	}
+}
+
+func TestBuildFilterClause_SingleEquality(t *testing.T) {
+	t.Parallel()
+	filters := []vector.Filter{
+		{Property: "genre", Operator: "=", Value: "Horror"},
+	}
+	clause, params, err := vector.BuildFilterClause(filters)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if clause != "node.`genre` = $f0" {
+		t.Errorf("unexpected clause: %q", clause)
+	}
+	if params["f0"] != "Horror" {
+		t.Errorf("unexpected param: %v", params["f0"])
+	}
+}
+
+func TestBuildFilterClause_MultipleFilters(t *testing.T) {
+	t.Parallel()
+	filters := []vector.Filter{
+		{Property: "genre", Operator: "=", Value: "Horror"},
+		{Property: "year", Operator: ">=", Value: 2000},
+	}
+	clause, params, err := vector.BuildFilterClause(filters)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContains(t, clause, "node.`genre` = $f0")
+	assertContains(t, clause, "node.`year` >= $f1")
+	assertContains(t, clause, " AND ")
+	if params["f0"] != "Horror" {
+		t.Errorf("f0 param mismatch: %v", params["f0"])
+	}
+	if params["f1"] != 2000 {
+		t.Errorf("f1 param mismatch: %v", params["f1"])
+	}
+}
+
+func TestBuildFilterClause_INOperator(t *testing.T) {
+	t.Parallel()
+	filters := []vector.Filter{
+		{Property: "genre", Operator: "IN", Value: []any{"Horror", "SciFi"}},
+	}
+	clause, params, err := vector.BuildFilterClause(filters)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertContains(t, clause, "node.`genre` IN $f0")
+	_ = params
+}
+
+func TestBuildFilterClause_INRequiresSlice(t *testing.T) {
+	t.Parallel()
+	filters := []vector.Filter{
+		{Property: "genre", Operator: "IN", Value: "Horror"},
+	}
+	_, _, err := vector.BuildFilterClause(filters)
+	if err == nil {
+		t.Error("expected error for IN with non-slice value")
+	}
+}
+
+func TestBuildFilterClause_AllOperators(t *testing.T) {
+	t.Parallel()
+	ops := []struct {
+		op  string
+		val any
+	}{
+		{"=", "x"},
+		{"<>", "x"},
+		{"<", 1},
+		{"<=", 1},
+		{">", 1},
+		{">=", 1},
+		{"CONTAINS", "x"},
+		{"STARTS WITH", "x"},
+		{"ENDS WITH", "x"},
+		{"IN", []any{"x"}},
+	}
+	for _, tc := range ops {
+		tc := tc
+		t.Run(tc.op, func(t *testing.T) {
+			t.Parallel()
+			filters := []vector.Filter{{Property: "name", Operator: tc.op, Value: tc.val}}
+			_, _, err := vector.BuildFilterClause(filters)
+			if err != nil {
+				t.Errorf("operator %q should be allowed, got error: %v", tc.op, err)
+			}
+		})
+	}
+}
+
+func TestBuildFilterClause_OperatorCaseInsensitive(t *testing.T) {
+	t.Parallel()
+	filters := []vector.Filter{
+		{Property: "title", Operator: "contains", Value: "neo"},
+	}
+	_, _, err := vector.BuildFilterClause(filters)
+	if err != nil {
+		t.Errorf("lower-case operator should be accepted: %v", err)
+	}
+}
+
+func TestBuildFilterClause_InvalidOperator(t *testing.T) {
+	t.Parallel()
+	filters := []vector.Filter{
+		{Property: "genre", Operator: "LIKE", Value: "%Horror%"},
+	}
+	_, _, err := vector.BuildFilterClause(filters)
+	if err == nil {
+		t.Error("expected error for invalid operator")
+	}
+}
+
+func TestBuildFilterClause_InjectionAttempts(t *testing.T) {
+	t.Parallel()
+	badProperties := []string{
+		"genre); DROP TABLE Movie; --",
+		"a b",
+		"1invalid",
+		"prop`name",
+		"",
+		"prop(name)",
+	}
+	for _, prop := range badProperties {
+		prop := prop
+		t.Run("bad_prop_"+prop, func(t *testing.T) {
+			t.Parallel()
+			filters := []vector.Filter{{Property: prop, Operator: "=", Value: "x"}}
+			_, _, err := vector.BuildFilterClause(filters)
+			if err == nil {
+				t.Errorf("expected rejection of property %q", prop)
+			}
+		})
+	}
+}
+
+func TestBuildFilterClause_ValidPropertyNames(t *testing.T) {
+	t.Parallel()
+	goodProperties := []string{"genre", "_internal", "myProp123", "A", "_"}
+	for _, prop := range goodProperties {
+		prop := prop
+		t.Run("good_prop_"+prop, func(t *testing.T) {
+			t.Parallel()
+			filters := []vector.Filter{{Property: prop, Operator: "=", Value: "x"}}
+			_, _, err := vector.BuildFilterClause(filters)
+			if err != nil {
+				t.Errorf("property %q should be accepted, got: %v", prop, err)
+			}
+		})
+	}
+}
+
+// assertContains checks that haystack contains needle.
+func assertContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("expected to contain %q\ngot:\n%s", needle, haystack)
+	}
+}
+
+// assertNotContains checks that haystack does not contain needle.
+func assertNotContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if strings.Contains(haystack, needle) {
+		t.Errorf("expected NOT to contain %q\ngot:\n%s", needle, haystack)
+	}
+}

--- a/internal/tools/vector/types.go
+++ b/internal/tools/vector/types.go
@@ -1,0 +1,20 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+package vector
+
+// Filter represents a single metadata filter applied during vector search.
+type Filter struct {
+	Property string `json:"property" jsonschema:"Node property name to filter on"`
+	Operator string `json:"operator" jsonschema:"One of: =, <>, <, <=, >, >=, IN, CONTAINS, STARTS WITH, ENDS WITH"`
+	Value    any    `json:"value"    jsonschema:"Value to compare against (scalar; list for IN)"`
+}
+
+// ResolvedIndex holds resolved metadata about a vector index obtained from SHOW VECTOR INDEXES.
+type ResolvedIndex struct {
+	Name              string
+	EntityType        string // "NODE" or "RELATIONSHIP"
+	Label             string // label (node) or relationship type
+	EmbeddingProperty string
+	Dimensions        int64 // 0 if unknown
+}

--- a/internal/tools/vector/vector_search_handler.go
+++ b/internal/tools/vector/vector_search_handler.go
@@ -1,0 +1,200 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+package vector
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/neo4j/mcp/internal/config"
+	"github.com/neo4j/mcp/internal/tools"
+)
+
+const (
+	defaultTopK     = 5
+	maxTopK         = 100
+	overFetchFactor = 5
+	maxFetchK       = 1000
+)
+
+// SearchHandler returns an MCP tool handler that performs semantic vector search.
+//
+//   - deps: tool dependencies (DBService must be non-nil at call time).
+//   - emb: embedding provider configuration read from server env vars — never from tool input.
+//   - useSearchClause: evaluated at call time — true → SEARCH clause (Neo4j ≥ 2026.01);
+//     false → db.index.vector.queryNodes() fallback. It is a function (not a bool) so the
+//     tool can be registered at startup, before the Neo4j version has been detected: in
+//     HTTP mode the version is determined on the first initialize, and the tool must be
+//     present in the startup tool list for clients (e.g. Copilot Studio) that import tools
+//     once and do not re-fetch after registration changes.
+//   - useAiTextEmbed: evaluated at call time, same lazy-registration rationale as
+//     useSearchClause — true → embed via ai.text.embed (Neo4j ≥ 2025.11); false → embed via
+//     the genai.vector.encode fallback (5.x, 2025.01–2025.10, incl. current Aura 5.x).
+func SearchHandler(deps *tools.ToolDependencies, emb config.EmbeddingConfig, useSearchClause func() bool, useAiTextEmbed func() bool) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return handleVectorSearch(ctx, request, deps, emb, useSearchClause(), useAiTextEmbed())
+	}
+}
+
+func handleVectorSearch(
+	ctx context.Context,
+	request mcp.CallToolRequest,
+	deps *tools.ToolDependencies,
+	emb config.EmbeddingConfig,
+	useSearchClause bool,
+	useAiTextEmbed bool,
+) (*mcp.CallToolResult, error) {
+	// Guard: DB service must be initialised.
+	if deps.DBService == nil {
+		msg := "database service is not initialized"
+		slog.Error(msg)
+		return mcp.NewToolResultError(msg), nil
+	}
+
+	// Guard: embedding must be configured.
+	if emb.Provider == "" {
+		msg := "vector-search is not available: embedding provider is not configured (set NEO4J_EMBEDDING_PROVIDER and related env vars)"
+		slog.Error(msg)
+		return mcp.NewToolResultError(msg), nil
+	}
+
+	// Bind arguments.
+	var args SearchInput
+	if err := request.BindArguments(&args); err != nil {
+		slog.Error("error binding vector-search arguments", "error", err)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// Validate query.
+	if args.Query == "" {
+		return mcp.NewToolResultError("query parameter is required and cannot be empty"), nil
+	}
+
+	// Apply TopK default and clamp.
+	topK := args.TopK
+	if topK <= 0 {
+		topK = defaultTopK
+	}
+	if topK > maxTopK {
+		topK = maxTopK
+	}
+
+	// Validate filters.
+	for i, f := range args.Filters {
+		if !safePropertyName.MatchString(f.Property) {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"filter[%d]: property '%s' is not a valid identifier; must match ^[A-Za-z_][A-Za-z0-9_]*$",
+				i, f.Property,
+			)), nil
+		}
+		if !allowedOperators[normalizeOperator(f.Operator)] {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"filter[%d]: operator '%s' is not allowed; permitted: =, <>, <, <=, >, >=, IN, CONTAINS, STARTS WITH, ENDS WITH",
+				i, f.Operator,
+			)), nil
+		}
+	}
+
+	// Resolve the vector index.
+	idx, err := ResolveIndex(ctx, deps.DBService, args.IndexName)
+	if err != nil {
+		slog.Error("vector-search: failed to resolve index", "error", err)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// Build embedding configuration map (never echoed to client). ai.text.embed and
+	// genai.vector.encode use different provider literals and config key shapes, so the
+	// builder is selected based on the same version gate as the embed function itself.
+	var provider string
+	var embedConfig map[string]any
+	if useAiTextEmbed {
+		provider, embedConfig, err = BuildEmbedConfig(emb)
+	} else {
+		provider, embedConfig, err = BuildGenaiVectorEncodeConfig(emb)
+	}
+	if err != nil {
+		slog.Error("vector-search: embedding config error", "error", err)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// Build filter clause.
+	filterClause, filterParams, err := BuildFilterClause(args.Filters)
+	if err != nil {
+		slog.Error("vector-search: filter clause error", "error", err)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// Compute fetchK: over-fetch when post-filtering so we have enough candidates.
+	fetchK := topK
+	if len(args.Filters) > 0 {
+		fetchK = topK * overFetchFactor
+		if fetchK > maxFetchK {
+			fetchK = maxFetchK
+		}
+	}
+
+	// Build the Cypher query.
+	cypher, err := BuildVectorQuery(idx, useSearchClause, useAiTextEmbed, filterClause)
+	if err != nil {
+		slog.Error("vector-search: query build error", "error", err)
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	// Assemble parameters. The embedConfig map is a bound parameter — never
+	// interpolated into query text — keeping the API key secure.
+	params := map[string]any{
+		"query":       args.Query,
+		"provider":    provider,
+		"embedConfig": embedConfig,
+		"topK":        topK,
+		"fetchK":      fetchK,
+	}
+	// queryNodes path needs the index name as a parameter (SEARCH path uses a literal).
+	if !useSearchClause {
+		params["indexName"] = idx.Name
+	}
+	// Merge filter value parameters.
+	for k, v := range filterParams {
+		params[k] = v
+	}
+
+	slog.Info("executing vector-search query",
+		"index", idx.Name,
+		"topK", topK,
+		"fetchK", fetchK,
+		"filters", len(args.Filters),
+		"useSearchClause", useSearchClause,
+		"useAiTextEmbed", useAiTextEmbed,
+	)
+
+	// Execute — errors are sanitised before returning to the client (§3/§11).
+	records, err := deps.DBService.ExecuteReadQuery(ctx, cypher, params)
+	if err != nil {
+		// Log the full error server-side but never return it to the client (it may
+		// contain the $embedConfig value depending on driver error formatting).
+		slog.Error("vector-search: query execution failed", "error", err)
+		return mcp.NewToolResultError(
+			"vector search failed; ensure the GenAI plugin is installed and " +
+				"the embedding provider credentials are valid. Check server logs for details.",
+		), nil
+	}
+
+	// Format results.
+	response, err := deps.DBService.Neo4jRecordsToJSON(records)
+	if err != nil {
+		slog.Error("vector-search: failed to format results", "error", err)
+		return mcp.NewToolResultError("vector search failed while formatting results; check server logs for details"), nil
+	}
+
+	return mcp.NewToolResultText(response), nil
+}
+
+// normalizeOperator normalises an operator string for lookup in allowedOperators.
+func normalizeOperator(op string) string {
+	upper := strings.ToUpper(strings.TrimSpace(op))
+	return strings.Join(strings.Fields(upper), " ")
+}

--- a/internal/tools/vector/vector_search_handler_test.go
+++ b/internal/tools/vector/vector_search_handler_test.go
@@ -1,0 +1,500 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+package vector_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/neo4j/mcp/internal/config"
+	db "github.com/neo4j/mcp/internal/database/mocks"
+	"github.com/neo4j/mcp/internal/tools"
+	"github.com/neo4j/mcp/internal/tools/vector"
+	"github.com/neo4j/neo4j-go-driver/v6/neo4j"
+	"go.uber.org/mock/gomock"
+)
+
+// staticUseSearch returns a useSearchClause function that always yields b.
+func staticUseSearch(b bool) func() bool {
+	return func() bool { return b }
+}
+
+// staticUseAiTextEmbed returns a useAiTextEmbed function that always yields b.
+func staticUseAiTextEmbed(b bool) func() bool {
+	return func() bool { return b }
+}
+
+// embedCfg returns a minimal, valid OpenAI embedding config.
+func embedCfg() config.EmbeddingConfig {
+	return config.EmbeddingConfig{
+		Provider: config.EmbeddingProviderOpenAI,
+		APIKey:   "sk-placeholder",
+		Model:    "text-embedding-3-small",
+	}
+}
+
+// buildRequest builds a CallToolRequest with the given arguments map.
+func buildRequest(t *testing.T, args map[string]any) mcp.CallToolRequest {
+	t.Helper()
+	return mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Arguments: args,
+		},
+	}
+}
+
+// singleIndexRecord returns a single-element record slice for SHOW VECTOR INDEXES.
+func singleIndexRecord() []*neo4j.Record {
+	return []*neo4j.Record{
+		{
+			Keys: []string{"name", "entityType", "labelsOrTypes", "properties", "options"},
+			Values: []any{
+				"moviePlots",
+				"NODE",
+				[]any{"Movie"},
+				[]any{"embedding"},
+				map[string]any{},
+			},
+		},
+	}
+}
+
+func TestVectorSearchHandler_NilDBService(t *testing.T) {
+	t.Parallel()
+	deps := &tools.ToolDependencies{DBService: nil}
+	handler := vector.SearchHandler(deps, embedCfg(), staticUseSearch(true), staticUseAiTextEmbed(true))
+	result, err := handler(context.Background(), buildRequest(t, map[string]any{"query": "hello"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for nil DBService")
+	}
+}
+
+func TestVectorSearchHandler_EmbeddingNotConfigured(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := db.NewMockService(ctrl)
+	// No expectations — handler should return early before any DB call
+	deps := &tools.ToolDependencies{DBService: mockDB}
+	emb := config.EmbeddingConfig{} // empty provider
+	handler := vector.SearchHandler(deps, emb, staticUseSearch(true), staticUseAiTextEmbed(true))
+	result, err := handler(context.Background(), buildRequest(t, map[string]any{"query": "hello"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result when embedding not configured")
+	}
+}
+
+func TestVectorSearchHandler_EmptyQuery(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := db.NewMockService(ctrl)
+	// No DB calls expected
+	deps := &tools.ToolDependencies{DBService: mockDB}
+	handler := vector.SearchHandler(deps, embedCfg(), staticUseSearch(true), staticUseAiTextEmbed(true))
+	result, err := handler(context.Background(), buildRequest(t, map[string]any{"query": ""}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result for empty query")
+	}
+}
+
+func TestVectorSearchHandler_TopKDefault(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := db.NewMockService(ctrl)
+
+	// Expect index resolution then query execution
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return(singleIndexRecord(), nil)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(map[string]any{})).
+		DoAndReturn(func(_ context.Context, _ string, params map[string]any) ([]*neo4j.Record, error) {
+			topK, ok := params["topK"]
+			if !ok {
+				t.Error("topK param missing")
+			} else if topK != 5 {
+				t.Errorf("expected default topK=5, got %v", topK)
+			}
+			return []*neo4j.Record{}, nil
+		})
+	mockDB.EXPECT().
+		Neo4jRecordsToJSON(gomock.Any()).
+		Return("[]", nil)
+
+	deps := &tools.ToolDependencies{DBService: mockDB}
+	handler := vector.SearchHandler(deps, embedCfg(), staticUseSearch(true), staticUseAiTextEmbed(true))
+	result, err := handler(context.Background(), buildRequest(t, map[string]any{"query": "sci-fi movies"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("unexpected error result: %v", extractText(result))
+	}
+}
+
+func TestVectorSearchHandler_TopKClamp(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := db.NewMockService(ctrl)
+
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return(singleIndexRecord(), nil)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(map[string]any{})).
+		DoAndReturn(func(_ context.Context, _ string, params map[string]any) ([]*neo4j.Record, error) {
+			if params["topK"] != 100 {
+				t.Errorf("expected clamped topK=100, got %v", params["topK"])
+			}
+			return []*neo4j.Record{}, nil
+		})
+	mockDB.EXPECT().
+		Neo4jRecordsToJSON(gomock.Any()).
+		Return("[]", nil)
+
+	deps := &tools.ToolDependencies{DBService: mockDB}
+	handler := vector.SearchHandler(deps, embedCfg(), staticUseSearch(true), staticUseAiTextEmbed(true))
+	// Request topK=500 — should be clamped to 100
+	result, err := handler(context.Background(), buildRequest(t, map[string]any{"query": "action", "topK": 500}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("unexpected error result: %v", extractText(result))
+	}
+}
+
+func TestVectorSearchHandler_InvalidFilterOperator(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := db.NewMockService(ctrl)
+	// No DB calls expected
+
+	deps := &tools.ToolDependencies{DBService: mockDB}
+	handler := vector.SearchHandler(deps, embedCfg(), staticUseSearch(true), staticUseAiTextEmbed(true))
+	filters := []any{
+		map[string]any{"property": "genre", "operator": "LIKE", "value": "%Horror%"},
+	}
+	result, err := handler(context.Background(), buildRequest(t, map[string]any{"query": "test", "filters": filters}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error for invalid filter operator")
+	}
+}
+
+func TestVectorSearchHandler_InvalidFilterProperty(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := db.NewMockService(ctrl)
+	// No DB calls expected
+
+	deps := &tools.ToolDependencies{DBService: mockDB}
+	handler := vector.SearchHandler(deps, embedCfg(), staticUseSearch(true), staticUseAiTextEmbed(true))
+	filters := []any{
+		map[string]any{"property": "bad prop!", "operator": "=", "value": "x"},
+	}
+	result, err := handler(context.Background(), buildRequest(t, map[string]any{"query": "test", "filters": filters}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error for invalid filter property name")
+	}
+}
+
+func TestVectorSearchHandler_ErrorSanitization(t *testing.T) {
+	t.Parallel()
+	// Critical security test: a driver error that might echo back the embedConfig value
+	// must NOT appear in the returned tool error text.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	sensitiveToken := "sk-super-secret-token-12345"
+	emb := config.EmbeddingConfig{
+		Provider: config.EmbeddingProviderOpenAI,
+		APIKey:   sensitiveToken,
+		Model:    "text-embedding-3-small",
+	}
+
+	mockDB := db.NewMockService(ctrl)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return(singleIndexRecord(), nil)
+
+	// Driver error that happens to contain the secret token (e.g., reflects back params)
+	driverErr := errors.New("query execution failed: params={embedConfig: {token: " + sensitiveToken + "}}")
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(map[string]any{})).
+		Return(nil, driverErr)
+
+	deps := &tools.ToolDependencies{DBService: mockDB}
+	handler := vector.SearchHandler(deps, emb, staticUseSearch(true), staticUseAiTextEmbed(true))
+	result, err := handler(context.Background(), buildRequest(t, map[string]any{"query": "find movies"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result")
+	}
+
+	// The error text returned to the client MUST NOT contain the sensitive token.
+	errText := extractText(result)
+	if strings.Contains(errText, sensitiveToken) {
+		t.Errorf("SECURITY VIOLATION: sensitive token leaked in client error: %q", errText)
+	}
+}
+
+func TestVectorSearchHandler_EmbeddingPropertyStrippedInQuery(t *testing.T) {
+	t.Parallel()
+	// Verify that the generated Cypher projects the embedding property as null.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := db.NewMockService(ctrl)
+
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return(singleIndexRecord(), nil)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(map[string]any{})).
+		DoAndReturn(func(_ context.Context, cypher string, _ map[string]any) ([]*neo4j.Record, error) {
+			// The Cypher must exclude the embedding property from results.
+			if !strings.Contains(cypher, "`embedding`: null") {
+				t.Errorf("cypher must strip embedding property; got:\n%s", cypher)
+			}
+			return []*neo4j.Record{}, nil
+		})
+	mockDB.EXPECT().
+		Neo4jRecordsToJSON(gomock.Any()).
+		Return("[]", nil)
+
+	deps := &tools.ToolDependencies{DBService: mockDB}
+	handler := vector.SearchHandler(deps, embedCfg(), staticUseSearch(true), staticUseAiTextEmbed(true))
+	result, err := handler(context.Background(), buildRequest(t, map[string]any{"query": "drama"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("unexpected error: %v", extractText(result))
+	}
+}
+
+func TestVectorSearchHandler_QueryNodesPath(t *testing.T) {
+	t.Parallel()
+	// Verify queryNodes path includes $indexName param and correct CALL.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := db.NewMockService(ctrl)
+
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return(singleIndexRecord(), nil)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(map[string]any{})).
+		DoAndReturn(func(_ context.Context, cypher string, params map[string]any) ([]*neo4j.Record, error) {
+			if !strings.Contains(cypher, "db.index.vector.queryNodes") {
+				t.Errorf("expected queryNodes in cypher; got:\n%s", cypher)
+			}
+			if params["indexName"] != "moviePlots" {
+				t.Errorf("expected indexName=moviePlots, got %v", params["indexName"])
+			}
+			return []*neo4j.Record{}, nil
+		})
+	mockDB.EXPECT().
+		Neo4jRecordsToJSON(gomock.Any()).
+		Return("[]", nil)
+
+	deps := &tools.ToolDependencies{DBService: mockDB}
+	// useSearchClause=false → queryNodes path
+	handler := vector.SearchHandler(deps, embedCfg(), staticUseSearch(false), staticUseAiTextEmbed(true))
+	result, err := handler(context.Background(), buildRequest(t, map[string]any{"query": "comedy"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("unexpected error: %v", extractText(result))
+	}
+}
+
+func TestVectorSearchHandler_FiltersIncreasesFetchK(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := db.NewMockService(ctrl)
+
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return(singleIndexRecord(), nil)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(map[string]any{})).
+		DoAndReturn(func(_ context.Context, _ string, params map[string]any) ([]*neo4j.Record, error) {
+			topK := params["topK"].(int)
+			fetchK := params["fetchK"].(int)
+			if fetchK <= topK {
+				t.Errorf("with filters fetchK (%d) should be > topK (%d)", fetchK, topK)
+			}
+			return []*neo4j.Record{}, nil
+		})
+	mockDB.EXPECT().
+		Neo4jRecordsToJSON(gomock.Any()).
+		Return("[]", nil)
+
+	deps := &tools.ToolDependencies{DBService: mockDB}
+	handler := vector.SearchHandler(deps, embedCfg(), staticUseSearch(true), staticUseAiTextEmbed(true))
+	filters := []any{
+		map[string]any{"property": "genre", "operator": "=", "value": "Horror"},
+	}
+	result, err := handler(context.Background(), buildRequest(t, map[string]any{
+		"query":   "scary movies",
+		"topK":    10,
+		"filters": filters,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("unexpected error: %v", extractText(result))
+	}
+}
+
+func TestVectorSearchHandler_SuccessfulSearch(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := db.NewMockService(ctrl)
+
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return(singleIndexRecord(), nil)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(map[string]any{})).
+		Return([]*neo4j.Record{}, nil)
+	mockDB.EXPECT().
+		Neo4jRecordsToJSON(gomock.Any()).
+		Return(`[{"node":{"title":"The Matrix"},"score":0.95}]`, nil)
+
+	deps := &tools.ToolDependencies{DBService: mockDB}
+	handler := vector.SearchHandler(deps, embedCfg(), staticUseSearch(true), staticUseAiTextEmbed(true))
+	result, err := handler(context.Background(), buildRequest(t, map[string]any{"query": "cyberpunk"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("unexpected error: %v", extractText(result))
+	}
+	text := extractText(result)
+	if !strings.Contains(text, "The Matrix") {
+		t.Errorf("expected result to contain 'The Matrix', got: %s", text)
+	}
+}
+
+func TestVectorSearchHandler_GenaiVectorEncodeFallback(t *testing.T) {
+	t.Parallel()
+	// useAiTextEmbed=false must select genai.vector.encode and the PascalCase provider
+	// literal (BuildGenaiVectorEncodeConfig), not ai.text.embed.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := db.NewMockService(ctrl)
+
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return(singleIndexRecord(), nil)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.AssignableToTypeOf(""), gomock.AssignableToTypeOf(map[string]any{})).
+		DoAndReturn(func(_ context.Context, cypher string, params map[string]any) ([]*neo4j.Record, error) {
+			if !strings.Contains(cypher, "genai.vector.encode") {
+				t.Errorf("expected genai.vector.encode in cypher; got:\n%s", cypher)
+			}
+			if strings.Contains(cypher, "ai.text.embed") {
+				t.Errorf("did not expect ai.text.embed in cypher; got:\n%s", cypher)
+			}
+			if params["provider"] != "OpenAI" {
+				t.Errorf("expected PascalCase provider 'OpenAI', got %v", params["provider"])
+			}
+			return []*neo4j.Record{}, nil
+		})
+	mockDB.EXPECT().
+		Neo4jRecordsToJSON(gomock.Any()).
+		Return("[]", nil)
+
+	deps := &tools.ToolDependencies{DBService: mockDB}
+	// useSearchClause=false, useAiTextEmbed=false → queryNodes + genai.vector.encode.
+	handler := vector.SearchHandler(deps, embedCfg(), staticUseSearch(false), staticUseAiTextEmbed(false))
+	result, err := handler(context.Background(), buildRequest(t, map[string]any{"query": "old aura instance"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("unexpected error: %v", extractText(result))
+	}
+}
+
+func TestVectorSearchHandler_GenaiVectorEncodeFallback_ErrorSanitization(t *testing.T) {
+	t.Parallel()
+	// Same security guarantee as TestVectorSearchHandler_ErrorSanitization, but for the
+	// genai.vector.encode fallback path: the API key must never leak into the client error.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	sensitiveToken := "sk-super-secret-token-67890"
+	emb := config.EmbeddingConfig{
+		Provider: config.EmbeddingProviderOpenAI,
+		APIKey:   sensitiveToken,
+		Model:    "text-embedding-3-small",
+	}
+
+	mockDB := db.NewMockService(ctrl)
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.Nil()).
+		Return(singleIndexRecord(), nil)
+
+	driverErr := errors.New("query execution failed: params={embedConfig: {token: " + sensitiveToken + "}}")
+	mockDB.EXPECT().
+		ExecuteReadQuery(gomock.Any(), gomock.Any(), gomock.AssignableToTypeOf(map[string]any{})).
+		Return(nil, driverErr)
+
+	deps := &tools.ToolDependencies{DBService: mockDB}
+	handler := vector.SearchHandler(deps, emb, staticUseSearch(false), staticUseAiTextEmbed(false))
+	result, err := handler(context.Background(), buildRequest(t, map[string]any{"query": "find movies"}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected error result")
+	}
+
+	errText := extractText(result)
+	if strings.Contains(errText, sensitiveToken) {
+		t.Errorf("SECURITY VIOLATION: sensitive token leaked in client error: %q", errText)
+	}
+}
+
+// extractText extracts the text from the first content item of a tool result.
+func extractText(result *mcp.CallToolResult) string {
+	if len(result.Content) == 0 {
+		return ""
+	}
+	if tc, ok := result.Content[0].(mcp.TextContent); ok {
+		return tc.Text
+	}
+	return ""
+}

--- a/internal/tools/vector/vector_search_spec.go
+++ b/internal/tools/vector/vector_search_spec.go
@@ -1,0 +1,32 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+package vector
+
+import (
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// SearchInput defines the arguments accepted by the vector-search tool.
+type SearchInput struct {
+	Query     string   `json:"query"               jsonschema:"Natural-language text to semantically search for"`
+	IndexName string   `json:"indexName,omitempty" jsonschema:"Name of the vector index to search. If omitted and exactly one vector index exists, it is used automatically."`
+	TopK      int      `json:"topK,omitempty"      jsonschema:"Number of nearest neighbors to return (default 5, max 100)"`
+	Filters   []Filter `json:"filters,omitempty"   jsonschema:"Optional metadata filters applied to results (AND-combined)"`
+}
+
+// SearchSpec returns the MCP tool definition for vector-search.
+func SearchSpec() mcp.Tool {
+	return mcp.NewTool("vector-search",
+		mcp.WithDescription(
+			"Semantic vector search over a Neo4j vector index. Embeds the query text and "+
+				"returns the most similar nodes with similarity scores. Use get-schema to discover "+
+				"available vector indexes and their node labels/properties."),
+		mcp.WithInputSchema[SearchInput](),
+		mcp.WithTitleAnnotation("Vector Search"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(true),
+	)
+}

--- a/manifest.json
+++ b/manifest.json
@@ -73,6 +73,83 @@
       "description": "Number of nodes to sample for schema inference",
       "required": false,
       "sensitive": false
+    },
+    "NEO4J_EMBEDDING_PROVIDER": {
+      "type": "string",
+      "title": "Embedding provider",
+      "description": "Enables the vector-search tool. One of: openai, azure-openai, vertexai, bedrock-titan",
+      "required": false,
+      "sensitive": false
+    },
+    "NEO4J_EMBEDDING_MODEL": {
+      "type": "string",
+      "title": "Embedding model",
+      "description": "Embedding model id, e.g. text-embedding-3-small. Must match the model used to create the stored embeddings",
+      "required": false,
+      "sensitive": false
+    },
+    "NEO4J_EMBEDDING_API_KEY": {
+      "type": "string",
+      "title": "Embedding API key",
+      "description": "Embedding provider API key (OpenAI/Azure/Vertex). Stored securely.",
+      "required": false,
+      "sensitive": true
+    },
+    "NEO4J_EMBEDDING_DIMENSIONS": {
+      "type": "string",
+      "title": "Embedding dimensions",
+      "description": "Optional. Only set if your model/index uses a reduced output dimension size",
+      "required": false,
+      "sensitive": false
+    },
+    "NEO4J_EMBEDDING_AZURE_RESOURCE": {
+      "type": "string",
+      "title": "Azure OpenAI resource",
+      "description": "Azure OpenAI resource name. Required when NEO4J_EMBEDDING_PROVIDER is azure-openai",
+      "required": false,
+      "sensitive": false
+    },
+    "NEO4J_EMBEDDING_VERTEX_PROJECT": {
+      "type": "string",
+      "title": "Vertex AI project",
+      "description": "Google Cloud project id. Required when NEO4J_EMBEDDING_PROVIDER is vertexai",
+      "required": false,
+      "sensitive": false
+    },
+    "NEO4J_EMBEDDING_VERTEX_REGION": {
+      "type": "string",
+      "title": "Vertex AI region",
+      "description": "Google Cloud region, e.g. us-central1. Required when NEO4J_EMBEDDING_PROVIDER is vertexai",
+      "required": false,
+      "sensitive": false
+    },
+    "NEO4J_EMBEDDING_VERTEX_PUBLISHER": {
+      "type": "string",
+      "title": "Vertex AI publisher",
+      "description": "Optional. Vertex AI model publisher (default: google)",
+      "required": false,
+      "sensitive": false
+    },
+    "NEO4J_EMBEDDING_AWS_ACCESS_KEY_ID": {
+      "type": "string",
+      "title": "AWS access key ID",
+      "description": "AWS access key id. Required when NEO4J_EMBEDDING_PROVIDER is bedrock-titan",
+      "required": false,
+      "sensitive": false
+    },
+    "NEO4J_EMBEDDING_AWS_SECRET_ACCESS_KEY": {
+      "type": "string",
+      "title": "AWS secret access key",
+      "description": "AWS secret access key. Required when NEO4J_EMBEDDING_PROVIDER is bedrock-titan. Stored securely.",
+      "required": false,
+      "sensitive": true
+    },
+    "NEO4J_EMBEDDING_AWS_REGION": {
+      "type": "string",
+      "title": "AWS region",
+      "description": "AWS region, e.g. us-east-1. Required when NEO4J_EMBEDDING_PROVIDER is bedrock-titan",
+      "required": false,
+      "sensitive": false
     }
   },
   "server": {
@@ -89,7 +166,18 @@
         "NEO4J_TELEMETRY": "${user_config.NEO4J_TELEMETRY}",
         "NEO4J_LOG_LEVEL": "${user_config.NEO4J_LOG_LEVEL}",
         "NEO4J_LOG_FORMAT": "${user_config.NEO4J_LOG_FORMAT}",
-        "NEO4J_SCHEMA_SAMPLE_SIZE": "${user_config.NEO4J_SCHEMA_SAMPLE_SIZE}"
+        "NEO4J_SCHEMA_SAMPLE_SIZE": "${user_config.NEO4J_SCHEMA_SAMPLE_SIZE}",
+        "NEO4J_EMBEDDING_PROVIDER": "${user_config.NEO4J_EMBEDDING_PROVIDER}",
+        "NEO4J_EMBEDDING_MODEL": "${user_config.NEO4J_EMBEDDING_MODEL}",
+        "NEO4J_EMBEDDING_API_KEY": "${user_config.NEO4J_EMBEDDING_API_KEY}",
+        "NEO4J_EMBEDDING_DIMENSIONS": "${user_config.NEO4J_EMBEDDING_DIMENSIONS}",
+        "NEO4J_EMBEDDING_AZURE_RESOURCE": "${user_config.NEO4J_EMBEDDING_AZURE_RESOURCE}",
+        "NEO4J_EMBEDDING_VERTEX_PROJECT": "${user_config.NEO4J_EMBEDDING_VERTEX_PROJECT}",
+        "NEO4J_EMBEDDING_VERTEX_REGION": "${user_config.NEO4J_EMBEDDING_VERTEX_REGION}",
+        "NEO4J_EMBEDDING_VERTEX_PUBLISHER": "${user_config.NEO4J_EMBEDDING_VERTEX_PUBLISHER}",
+        "NEO4J_EMBEDDING_AWS_ACCESS_KEY_ID": "${user_config.NEO4J_EMBEDDING_AWS_ACCESS_KEY_ID}",
+        "NEO4J_EMBEDDING_AWS_SECRET_ACCESS_KEY": "${user_config.NEO4J_EMBEDDING_AWS_SECRET_ACCESS_KEY}",
+        "NEO4J_EMBEDDING_AWS_REGION": "${user_config.NEO4J_EMBEDDING_AWS_REGION}"
       }
     }
   },
@@ -109,6 +197,10 @@
     {
       "name": "list-gds-procedures",
       "description": "List GDS procedures available in the instance"
+    },
+    {
+      "name": "vector-search",
+      "description": "Semantic vector search over a Neo4j vector index (requires an embedding provider)"
     }
   ],
   "compatibility": {


### PR DESCRIPTION
## Summary

Adds a single new MCP tool, `vector-search`, that performs semantic vector similarity search over an existing Neo4j vector index. The tool embeds the user's natural-language query **at query time, inside Neo4j** (via the GenAI plugin), runs the similarity search, and returns the most similar nodes with their scores. It supports optional structured metadata filtering and works over both the STDIO and HTTP transports.

The tool is registered only when an embedding provider is configured, so servers without embedding configuration are unaffected.

## Motivation / use case

The server can already run and read Cypher, but it has no first-class way to do semantic retrieval. The driving use case is a hosted deployment (Microsoft Copilot Studio → Cloud Run → Neo4j Aura) where an agent needs to find semantically relevant nodes from natural language and then chain into `read-cypher` for graph traversal. Doing the embedding **in the database** means the MCP server never has to ship vectors around or hold per-request user credentials — it holds only a single server-side embedding API key.

## What's added

- **One `vector-search` tool** (not one tool per index). The index is resolved per call via `SHOW VECTOR INDEXES`: pass an optional `indexName`, or omit it and the tool auto-selects when exactly one vector index exists (erroring with the list of candidates when there are several, and a clear message when there are none).
- **Query-time, in-database embeddings** — the query text is embedded inside Neo4j; no embedding happens in the server process.
- **Provider-agnostic embedding config** — OpenAI, Azure OpenAI, Vertex AI, and Bedrock Titan, all via `NEO4J_EMBEDDING_*` environment variables.
- **Optional structured metadata filters** — `{property, operator, value}`, applied as a post-filter.
- New package `internal/tools/vector/` (spec, index resolver, embedding-config builders, query builder, handler) plus embedding-config parsing/validation in `internal/config`, version detection in `internal/server/server.go`, and startup registration in `internal/server/tools_register.go`.
- README "Vector search configuration" section, `manifest.json` updates, and changelog entries.
- Extensive unit tests across the new package and the config/server changes.

## Design decisions

<details>
<summary><strong>Version-gated embedding function (<code>ai.text.embed</code> → <code>genai.vector.encode</code>)</strong></summary>

`ai.text.embed()` was only introduced in Neo4j **2025.11**. Instances on older versions — including freshly provisioned Aura Professional, which currently runs `5.27-aura` — do not have it, so a naive implementation fails on today's Aura.

The tool detects the Neo4j version from `dbms.components()` at startup and:
- uses **`ai.text.embed`** on Neo4j **>= 2025.11**, and
- automatically falls back to the deprecated-but-present **`genai.vector.encode`** on older versions.

`genai.vector.encode` uses PascalCase provider names (`OpenAI`, `AzureOpenAI`, `VertexAI`, `Bedrock`) and different config keys (flat `dimensions`; Azure `deployment` instead of `model`; Vertex `projectId`), so a dedicated config builder produces the fallback shape. No user action is required either way.
</details>

<details>
<summary><strong>Version-gated query strategy (<code>SEARCH</code> clause → <code>db.index.vector.queryNodes()</code>)</strong></summary>

The tool uses the **`SEARCH` clause** on Neo4j **>= 2026.01** and falls back to **`db.index.vector.queryNodes()` / `queryRelationships()`** on 2025.x. Both paths share the same filter/return/order/limit tail.
</details>

<details>
<summary><strong>Registered at startup (not deferred) so HTTP clients can discover it</strong></summary>

Version-dependent behavior would normally suggest deferring registration until after version detection (as the GDS tools do). But some HTTP clients — notably Copilot Studio — import the tool list **once** and never re-fetch it, so a tool that appears only after the `initialize` handshake is invisible to them.

Instead, `vector-search` is registered **at startup**, gated solely on embedding configuration (known at startup in both transports). The two version gates are read **lazily at call time** via `func() bool` backed by `atomic.Bool`, which `verifyRequirements` sets once the Neo4j version is known. This keeps the tool in the initial tool list while still selecting the correct query and embedding strategy per call.
</details>

<details>
<summary><strong>Metadata filters as a post-filter with over-fetch</strong></summary>

Filters are applied as a post-filter after the vector search. To keep result quality reasonable when filters are present, the tool over-fetches candidates (`topK × 5`, capped at 1000) before filtering down to `topK`. Operators are validated against an allow-list (`=`, `<>`, `<`, `<=`, `>`, `>=`, `IN`, `CONTAINS`, `STARTS WITH`, `ENDS WITH`) and property names against a strict identifier pattern.
</details>

## Configuration

The tool is enabled only when an embedding provider is configured. The target instance must have the GenAI plugin available (standard on Aura) and at least one vector index. The embedding **model must match the model used to create the stored embeddings**.

| Variable | Purpose |
| --- | --- |
| `NEO4J_EMBEDDING_PROVIDER` | `openai`, `azure-openai`, `vertexai`, or `bedrock-titan` |
| `NEO4J_EMBEDDING_MODEL` | Embedding model name |
| `NEO4J_EMBEDDING_API_KEY` | Provider API key (server-side only) |
| `NEO4J_EMBEDDING_DIMENSIONS` | Output dimensions (optional) |
| `NEO4J_EMBEDDING_AZURE_RESOURCE` | Azure OpenAI resource |
| `NEO4J_EMBEDDING_VERTEX_PROJECT` | Vertex AI project |
| `NEO4J_EMBEDDING_VERTEX_REGION` | Vertex AI region |
| `NEO4J_EMBEDDING_VERTEX_PUBLISHER` | Vertex AI publisher (default `google`) |
| `NEO4J_EMBEDDING_AWS_ACCESS_KEY_ID` | Bedrock access key ID |
| `NEO4J_EMBEDDING_AWS_SECRET_ACCESS_KEY` | Bedrock secret access key |
| `NEO4J_EMBEDDING_AWS_REGION` | Bedrock region |

## Security considerations

- **API key never interpolated.** The provider, model, and API key are assembled into an embedding-config map and passed to the embedding function as a **bound Cypher parameter** (`$embedConfig`) — never string-interpolated into query text.
- **Never a tool input, never returned.** The API key is read only from the server environment. It is never accepted as a tool input and never returned to clients.
- **Errors sanitized.** Client-facing errors are generic ("ensure the GenAI plugin is installed and the embedding provider credentials are valid; check server logs for details"); full errors are logged server-side only.
- **Embedding property stripped.** The stored embedding vector is stripped from returned nodes via Cypher map-projection (using the property discovered from the index, not a hardcoded name).
- **Identifier hardening.** Index name and label are escaped (backtick-quoted) before interpolation; filter property names are validated against a strict pattern and operators against an allow-list.

## Testing

- `go build`, `go vet`, `go test -race`, and `golangci-lint run` all green (0 lint issues).
- **Verified end-to-end against a live Neo4j Aura `5.27-aura` instance** through the actual MCP server in Claude Desktop, exercising the `genai.vector.encode` fallback path (OpenAI `text-embedding-3-small`, 1536-dim index): the tool embeds the query and returns ranked results.
- **Validated in Microsoft Copilot Studio** (Copilot Studio → Cloud Run → Aura): the tool lists in the imported tool set, executes, and chains with `read-cypher` for graph traversal.

## Out of scope (future work)

Intentionally deferred to keep this PR focused:
- Hybrid and fulltext search tools
- Graph-traversal / retrieval-query tools
- `get-schema` enhancement to discover vector/fulltext indexes
- In-index `WHERE`/`IN` filter push-down (uses a post-filter for now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
