### PR TITLE
Fix docker printed version (port to 2.x)

### DIFF
--- a/.github/workflows/docker-release-alpha.yml
+++ b/.github/workflows/docker-release-alpha.yml
@@ -33,6 +33,8 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          build-args: |
+            VERSION=${{ inputs.version }}
           tags: ${{ env.DOCKER_REPOSITORY }}:${{ inputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -59,6 +59,8 @@ jobs:
           file: ./Dockerfile
           push: true
           platforms: linux/${{ matrix.arch }}
+          build-args: |
+            VERSION=${{ needs.get-version.outputs.version }}
           tags: ${{ env.DOCKER_REPOSITORY }}:${{ matrix.arch }}-${{ needs.get-version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Builder stage
 FROM golang:1.26-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
 
+ARG VERSION=development
+
 LABEL io.modelcontextprotocol.server.name="io.github.neo4j/mcp"
 
 WORKDIR /build
@@ -19,6 +21,7 @@ COPY . .
 
 # Build the binary
 RUN CGO_ENABLED=0 GOOS=linux go build -C cmd/neo4j-mcp -a -installsuffix cgo \
+    -ldflags "-X main.Version=${VERSION}" \
     -o ../../neo4j-mcp
 
 # Runtime stage


### PR DESCRIPTION
Ports the Docker printed-version fix from #308 to the `2.x` branch.