### PR TITLE
Remove minimumReleaseAge check for digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,10 @@
     "minimumReleaseAge": "3 days",
     "packageRules": [
         {
+            "matchUpdateTypes": ["digest", "pinDigest"],
+            "minimumReleaseAge": null
+        },
+        {
             "matchUpdateTypes": ["major"],
             "groupName": null
         },


### PR DESCRIPTION
Eliminate the minimumReleaseAge requirement for digest and pinDigest updates in the configuration so the auto-merge can kick in once the PR is approved.

(see: https://github.com/renovatebot/renovate/discussions/39781 for the root cause, digest updates are usually missing the timestamp so our updates were left stale 14+ days until one of us merges them)

