### PR TITLE
Remove duplicity of verifyRequirements from every requests, do not check gds if not enabled.

### DIFF
--- a/.changes/unreleased/Patch-20260723-171317.yaml
+++ b/.changes/unreleased/Patch-20260723-171317.yaml
@@ -1,0 +1,4 @@
+kind: Patch
+body: |
+  Requirement checks now run only on MCP `initialize`, and GDS is verified only when `list-gds-procedures` is enabled.
+time: 2026-07-23T17:13:17.244117+01:00

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -252,6 +252,8 @@ func (s *Neo4jMCPServer) verifyRequirements(ctx context.Context) error {
 
 // isToolEnabled reports whether a tool is enabled for the current request.
 // Per-request HTTP headers take precedence over server configuration.
+// When per-request header is present GetTools returns nil. while
+// s.config.Tools will always have all the tools available at startup.
 func (s *Neo4jMCPServer) isToolEnabled(ctx context.Context, toolName string) bool {
 	if tools := mcpcontext.GetTools(ctx); tools != nil {
 		return slices.Contains(*tools, toolName)
@@ -512,15 +514,12 @@ func jsonRPCMethod(message any) (mcp.MCPMethod, bool) {
 	if !ok {
 		return "", false
 	}
-
-	var envelope struct {
-		Method mcp.MCPMethod `json:"method"`
-	}
+	var envelope mcp.JSONRPCRequest
 	if err := json.Unmarshal(raw, &envelope); err != nil {
-		return "", false
+		return mcp.MCPMethod(""), false
 	}
 
-	return envelope.Method, envelope.Method != ""
+	return mcp.MCPMethod(envelope.Request.Method), envelope.Method != ""
 }
 
 // handleToolCallComplete is called after every tool call completes

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,6 +6,7 @@ package server
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -469,17 +470,44 @@ func (s *Neo4jMCPServer) configureHooks() *server.Hooks {
 
 	hooks.AddAfterCallTool(s.handleToolCallComplete)
 
-	hooks.AddOnRequestInitialization(func(ctx context.Context, _ any, _ any) error {
-		slog.Info("Initialize request: verifying requirements...")
-		err := s.verifyRequirements(ctx)
-		if err != nil {
-			return err
-		}
-		s.emitConnectionInitializedEvent(ctx)
-		return nil
-	})
+	hooks.AddOnRequestInitialization(s.onRequestInitialization)
 
 	return hooks
+}
+
+// onRequestInitialization verifies Neo4j requirements during the initialize handshake.
+// Only initialize requests are checked; other methods pass through unchanged.
+// onRequestInitialization naming from the mcp-go sdk may be counter intuitive as is it
+// unrelated to the MCP initialize method requests and is triggered by all requests.
+func (s *Neo4jMCPServer) onRequestInitialization(ctx context.Context, _ any, message any) error {
+	method, ok := jsonRPCMethod(message)
+	if !ok || method != mcp.MethodInitialize {
+		return nil
+	}
+
+	slog.Info("Initialize request: verifying requirements...")
+	if err := s.verifyRequirements(ctx); err != nil {
+		return err
+	}
+	s.emitConnectionInitializedEvent(ctx)
+	return nil
+}
+
+// jsonRPCMethod extracts the JSON-RPC method from a raw request envelope.
+func jsonRPCMethod(message any) (mcp.MCPMethod, bool) {
+	raw, ok := message.(json.RawMessage)
+	if !ok {
+		return "", false
+	}
+
+	var envelope struct {
+		Method mcp.MCPMethod `json:"method"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return "", false
+	}
+
+	return envelope.Method, envelope.Method != ""
 }
 
 // handleToolCallComplete is called after every tool call completes

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -229,6 +229,10 @@ func (s *Neo4jMCPServer) verifyRequirements(ctx context.Context) error {
 	if !ok || !apocMetaSchemaAvailable {
 		return fmt.Errorf("please ensure the APOC plugin is installed and includes the 'meta' component")
 	}
+	if !s.isToolEnabled(ctx, "list-gds-procedures") {
+		return nil
+	}
+
 	// Call gds.version procedure to determine if GDS is installed
 	records, err = s.dbService.ExecuteReadQuery(ctx, "RETURN gds.version() as gdsVersion", nil)
 	if err != nil {
@@ -244,6 +248,15 @@ func (s *Neo4jMCPServer) verifyRequirements(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// isToolEnabled reports whether a tool is enabled for the current request.
+// Per-request HTTP headers take precedence over server configuration.
+func (s *Neo4jMCPServer) isToolEnabled(ctx context.Context, toolName string) bool {
+	if tools := mcpcontext.GetTools(ctx); tools != nil {
+		return slices.Contains(*tools, toolName)
+	}
+	return slices.Contains(s.config.Tools, toolName)
 }
 
 // emitServerStartupEvent emits the server startup event immediately with available info (no DB query)

--- a/internal/server/server_http_lifecycle_test.go
+++ b/internal/server/server_http_lifecycle_test.go
@@ -120,6 +120,45 @@ func TestNeo4jMCPServerHTTPMode(t *testing.T) {
 		assertNoCloseOrStopError(t, s, errChan)
 	})
 
+	t.Run("Server does not re-verify on subsequent MCP requests", func(t *testing.T) {
+		mockDB := db.NewMockService(ctrl)
+		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "RETURN 1 as first", gomock.Any()).Times(1).Return([]*neo4j.Record{
+			{
+				Keys:   []string{"first"},
+				Values: []any{int64(1)},
+			},
+		}, nil)
+		checkApocMetaSchemaQuery := "SHOW PROCEDURES YIELD name WHERE name = 'apoc.meta.schema' RETURN count(name) > 0 AS apocMetaSchemaAvailable"
+		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), checkApocMetaSchemaQuery, gomock.Any()).Times(1).Return([]*neo4j.Record{
+			{
+				Keys:   []string{"apocMetaSchemaAvailable"},
+				Values: []any{bool(true)},
+			},
+		}, nil)
+		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "RETURN gds.version() as gdsVersion", gomock.Any()).Times(1).Return([]*neo4j.Record{
+			{
+				Keys:   []string{"gdsVersion"},
+				Values: []any{string("2.22.0")},
+			},
+		}, nil)
+		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "CALL dbms.components()", gomock.Any()).Times(1)
+
+		s, errChan := createHTTPServer(t, cfg, mockDB, analyticsService)
+		mcpClient := createStreamableHTTPClient(uri, defaultHeaders())
+
+		_, err := mcpClient.Initialize(context.Background(), mcp.InitializeRequest{})
+		if err != nil {
+			t.Fatalf("error while initialize request: %v", err)
+		}
+
+		_, err = mcpClient.ListTools(context.Background(), mcp.ListToolsRequest{})
+		if err != nil {
+			t.Fatalf("error while list tools request: %v", err)
+		}
+
+		assertNoCloseOrStopError(t, s, errChan)
+	})
+
 	t.Run("Server handles database connectivity errors gracefully", func(t *testing.T) {
 		mockDB := db.NewMockService(ctrl)
 		// in HTTP the serve should keep running even if the connectivity check fails.

--- a/internal/server/server_http_lifecycle_test.go
+++ b/internal/server/server_http_lifecycle_test.go
@@ -159,6 +159,75 @@ func TestNeo4jMCPServerHTTPMode(t *testing.T) {
 		assertNoCloseOrStopError(t, s, errChan)
 	})
 
+	t.Run("skips GDS verification when X-Neo4j-MCP-Tools excludes list-gds-procedures", func(t *testing.T) {
+		mockDB := db.NewMockService(ctrl)
+		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "RETURN 1 as first", gomock.Any()).Times(1).Return([]*neo4j.Record{
+			{
+				Keys:   []string{"first"},
+				Values: []any{int64(1)},
+			},
+		}, nil)
+		checkApocMetaSchemaQuery := "SHOW PROCEDURES YIELD name WHERE name = 'apoc.meta.schema' RETURN count(name) > 0 AS apocMetaSchemaAvailable"
+		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), checkApocMetaSchemaQuery, gomock.Any()).Times(1).Return([]*neo4j.Record{
+			{
+				Keys:   []string{"apocMetaSchemaAvailable"},
+				Values: []any{bool(true)},
+			},
+		}, nil)
+		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "RETURN gds.version() as gdsVersion", gomock.Any()).Times(0)
+		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "CALL dbms.components()", gomock.Any()).Times(1)
+
+		s, errChan := createHTTPServer(t, cfg, mockDB, analyticsService)
+
+		headers := defaultHeaders()
+		headers["X-Neo4j-MCP-Tools"] = "read-cypher, get-schema"
+		mcpClient := createStreamableHTTPClient(uri, headers)
+
+		_, err := mcpClient.Initialize(context.Background(), mcp.InitializeRequest{})
+		if err != nil {
+			t.Fatalf("error while initialize request: %v", err)
+		}
+
+		assertNoCloseOrStopError(t, s, errChan)
+	})
+
+	t.Run("runs GDS verification when X-Neo4j-MCP-Tools includes list-gds-procedures", func(t *testing.T) {
+		mockDB := db.NewMockService(ctrl)
+		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "RETURN 1 as first", gomock.Any()).Times(1).Return([]*neo4j.Record{
+			{
+				Keys:   []string{"first"},
+				Values: []any{int64(1)},
+			},
+		}, nil)
+		checkApocMetaSchemaQuery := "SHOW PROCEDURES YIELD name WHERE name = 'apoc.meta.schema' RETURN count(name) > 0 AS apocMetaSchemaAvailable"
+		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), checkApocMetaSchemaQuery, gomock.Any()).Times(1).Return([]*neo4j.Record{
+			{
+				Keys:   []string{"apocMetaSchemaAvailable"},
+				Values: []any{bool(true)},
+			},
+		}, nil)
+		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "RETURN gds.version() as gdsVersion", gomock.Any()).Times(1).Return([]*neo4j.Record{
+			{
+				Keys:   []string{"gdsVersion"},
+				Values: []any{string("2.22.0")},
+			},
+		}, nil)
+		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "CALL dbms.components()", gomock.Any()).Times(1)
+
+		s, errChan := createHTTPServer(t, cfg, mockDB, analyticsService)
+
+		headers := defaultHeaders()
+		headers["X-Neo4j-MCP-Tools"] = "read-cypher, list-gds-procedures"
+		mcpClient := createStreamableHTTPClient(uri, headers)
+
+		_, err := mcpClient.Initialize(context.Background(), mcp.InitializeRequest{})
+		if err != nil {
+			t.Fatalf("error while initialize request: %v", err)
+		}
+
+		assertNoCloseOrStopError(t, s, errChan)
+	})
+
 	t.Run("Server handles database connectivity errors gracefully", func(t *testing.T) {
 		mockDB := db.NewMockService(ctrl)
 		// in HTTP the serve should keep running even if the connectivity check fails.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -28,6 +28,7 @@ func TestNewNeo4jMCPServer(t *testing.T) {
 		Username:      "neo4j",
 		Password:      "password",
 		Database:      "neo4j",
+		Tools:         config.AvailableTools,
 		TransportMode: config.TransportModeStdio,
 	}
 
@@ -77,6 +78,7 @@ func TestInitializeRequestHook(t *testing.T) {
 		Username:      "neo4j",
 		Password:      "password",
 		Database:      "neo4j",
+		Tools:         config.AvailableTools,
 		TransportMode: config.TransportModeStdio,
 	}
 
@@ -225,6 +227,46 @@ func TestInitializeRequestHook(t *testing.T) {
 			t.Fatalf("Expect no error during initialization, got: %s", err.Error())
 		}
 	})
+
+	t.Run("skips GDS verification when list-gds-procedures is not enabled", func(t *testing.T) {
+		cfgWithoutGDS := &config.Config{
+			URI:           "bolt://test-host:7687",
+			Username:      "neo4j",
+			Password:      "password",
+			Database:      "neo4j",
+			Tools:         []string{"read-cypher", "write-cypher", "get-schema"},
+			TransportMode: config.TransportModeStdio,
+		}
+		mockDB := db.NewMockService(ctrl)
+		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "RETURN 1 as first", gomock.Any()).Times(1).Return([]*neo4j.Record{
+			{
+				Keys:   []string{"first"},
+				Values: []any{int64(1)},
+			},
+		}, nil)
+		checkApocMetaSchemaQuery := "SHOW PROCEDURES YIELD name WHERE name = 'apoc.meta.schema' RETURN count(name) > 0 AS apocMetaSchemaAvailable"
+		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), checkApocMetaSchemaQuery, gomock.Any()).Times(1).Return([]*neo4j.Record{
+			{
+				Keys:   []string{"apocMetaSchemaAvailable"},
+				Values: []any{bool(true)},
+			},
+		}, nil)
+		mockDB.EXPECT().ExecuteReadQuery(gomock.Any(), "CALL dbms.components()", gomock.Any()).Times(1)
+
+		s := server.NewNeo4jMCPServer("test-version", cfgWithoutGDS, mockDB, analyticsService)
+		err := s.Start()
+		if err != nil {
+			t.Errorf("error while starting the MCP Server")
+		}
+		inProcessClient, err := client.NewInProcessClient(s.MCPServer)
+		if err != nil {
+			t.Fatalf("Unexpected error during InProcessClient creation, %s", err.Error())
+		}
+		_, err = inProcessClient.Initialize(context.Background(), mcp.InitializeRequest{})
+		if err != nil {
+			t.Fatalf("Expect no error during initialization, got: %s", err.Error())
+		}
+	})
 }
 
 func TestNewNeo4jMCPServerEvents(t *testing.T) {
@@ -237,6 +279,7 @@ func TestNewNeo4jMCPServerEvents(t *testing.T) {
 		Username:      "neo4j",
 		Password:      "password",
 		Database:      "neo4j",
+		Tools:         config.AvailableTools,
 		TransportMode: config.TransportModeStdio,
 	}
 


### PR DESCRIPTION
Fixes verifyRequirements checks that were running on every MCP request instead of only on initialization.
This was due to the fact that the hook `onRequestInitialization` is invoked at every request initialization and not only in `initialize` requests.
Verify GDS is only excuted when list-gds-procedures is enabled (via NEO4J_MCP_TOOLS / CLI or X-Neo4j-MCP-Tools)
