### PR TITLE
add configurable request timeout with per-request HTTP override

### DIFF
--- a/.changes/unreleased/Minor-20260730-181827.yaml
+++ b/.changes/unreleased/Minor-20260730-181827.yaml
@@ -1,0 +1,7 @@
+kind: Minor
+body: |
+  MCP requests are now bounded by a timeout, 3m by default and 30m at most.
+  - Set the server limit with `NEO4J_MCP_REQUEST_TIMEOUT` or `--neo4j-request-timeout` (e.g. `45s`, `5m`)
+  - HTTP mode accepts a per-request `X-Neo4j-MCP-Request-Timeout` header, which can only lower the server limit; larger, non-positive, or malformed values return `400 Bad Request`
+  - Tool calls and `initialize` that run past the limit are cancelled and return a `request timed out after <duration>` error
+time: 2026-07-30T18:18:27.279087+01:00

--- a/cmd/neo4j-mcp/main.go
+++ b/cmd/neo4j-mcp/main.go
@@ -51,6 +51,7 @@ func main() {
 		AuthHeaderName:                cliArgs.AuthHeaderName,
 		AllowUnauthenticatedPing:      cliArgs.HTTPAllowUnauthenticatedPing,
 		AllowUnauthenticatedToolsList: cliArgs.HTTPAllowUnauthenticatedToolsList,
+		RequestTimeout:                cliArgs.RequestTimeout,
 	})
 	if err != nil {
 		// Can't use logger here yet, so just print to stderr

--- a/internal/cli/args.go
+++ b/internal/cli/args.go
@@ -40,7 +40,7 @@ Options:
   --neo4j-http-auth-header-name <HEADER> Name of the HTTP header to read auth credentials from (overrides NEO4J_HTTP_AUTH_HEADER_NAME)
   --neo4j-http-allow-unauthenticated-ping <BOOLEAN> Allow unauthenticated ping health checks: true or false (overrides NEO4J_HTTP_ALLOW_UNAUTHENTICATED_PING)
   --neo4j-http-allow-unauthenticated-tools-list <BOOLEAN> Allow unauthenticated tools list: true or false (overrides NEO4J_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST)
-  --neo4j-request-timeout <DURATION>  Maximum duration for a single MCP request (overrides environment variable NEO4J_MCP_REQUEST_TIMEOUT)
+  --neo4j-request-timeout <DURATION>  Maximum duration for a single MCP request, up to 30m. Also caps the per-request X-Neo4j-MCP-Request-Timeout header in HTTP mode (overrides environment variable NEO4J_MCP_REQUEST_TIMEOUT)
 
 Required Environment Variables:
   NEO4J_URI       Neo4j database URI
@@ -64,7 +64,7 @@ Optional Environment Variables:
   NEO4J_HTTP_AUTH_HEADER_NAME Name of the HTTP header to read auth credentials from (default: Authorization)
   NEO4J_HTTP_ALLOW_UNAUTHENTICATED_PING Allow unauthenticated ping health checks (default: false)
   NEO4J_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST Allow unauthenticated tool listing (default: false)
-  NEO4J_MCP_REQUEST_TIMEOUT Maximum duration for a single MCP request (default: 3m)
+  NEO4J_MCP_REQUEST_TIMEOUT Maximum duration for a single MCP request (default: 3m, maximum: 30m)
 
 Examples:
   # Using environment variables
@@ -151,7 +151,7 @@ func ParseConfigFlags() *Args {
 	neo4jAuthHeaderName := flag.String("neo4j-http-auth-header-name", "", "Name of the HTTP header to read auth credentials from (overrides NEO4J_HTTP_AUTH_HEADER_NAME env var)")
 	neo4jHTTPAllowUnauthenticatedPing := flag.String("neo4j-http-allow-unauthenticated-ping", "", "Allow unauthenticated ping health checks: true or false (overrides NEO4J_HTTP_ALLOW_UNAUTHENTICATED_PING env var)")
 	neo4jHTTPAllowUnauthenticatedToolsList := flag.String("neo4j-http-allow-unauthenticated-tools-list", "", "Allow unauthenticated tools listing: true or false (overrides NEO4J_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST env var)")
-	neo4jRequestTimeout := flag.String("neo4j-request-timeout", "", "Maximum duration for a single MCP request (overrides NEO4J_MCP_REQUEST_TIMEOUT env var)")
+	neo4jRequestTimeout := flag.String("neo4j-request-timeout", "", "Maximum duration for a single MCP request, up to 30m (overrides NEO4J_MCP_REQUEST_TIMEOUT env var)")
 
 	flag.Parse()
 

--- a/internal/cli/args.go
+++ b/internal/cli/args.go
@@ -40,6 +40,7 @@ Options:
   --neo4j-http-auth-header-name <HEADER> Name of the HTTP header to read auth credentials from (overrides NEO4J_HTTP_AUTH_HEADER_NAME)
   --neo4j-http-allow-unauthenticated-ping <BOOLEAN> Allow unauthenticated ping health checks: true or false (overrides NEO4J_HTTP_ALLOW_UNAUTHENTICATED_PING)
   --neo4j-http-allow-unauthenticated-tools-list <BOOLEAN> Allow unauthenticated tools list: true or false (overrides NEO4J_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST)
+  --neo4j-request-timeout <DURATION>  Maximum duration for a single MCP request (overrides environment variable NEO4J_MCP_REQUEST_TIMEOUT)
 
 Required Environment Variables:
   NEO4J_URI       Neo4j database URI
@@ -63,6 +64,7 @@ Optional Environment Variables:
   NEO4J_HTTP_AUTH_HEADER_NAME Name of the HTTP header to read auth credentials from (default: Authorization)
   NEO4J_HTTP_ALLOW_UNAUTHENTICATED_PING Allow unauthenticated ping health checks (default: false)
   NEO4J_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST Allow unauthenticated tool listing (default: false)
+  NEO4J_MCP_REQUEST_TIMEOUT Maximum duration for a single MCP request (default: 3m)
 
 Examples:
   # Using environment variables
@@ -94,6 +96,7 @@ type Args struct {
 	AuthHeaderName                    string
 	HTTPAllowUnauthenticatedPing      string
 	HTTPAllowUnauthenticatedToolsList string
+	RequestTimeout                    string
 }
 
 // this is a list of known configuration flags to be skipped in HandleArgs
@@ -117,6 +120,7 @@ var argsSlice = []string{
 	"--neo4j-http-auth-header-name",
 	"--neo4j-http-allow-unauthenticated-ping",
 	"--neo4j-http-allow-unauthenticated-tools-list",
+	"--neo4j-request-timeout",
 }
 
 // ParseConfigFlags parses CLI flags and returns configuration values.
@@ -147,6 +151,7 @@ func ParseConfigFlags() *Args {
 	neo4jAuthHeaderName := flag.String("neo4j-http-auth-header-name", "", "Name of the HTTP header to read auth credentials from (overrides NEO4J_HTTP_AUTH_HEADER_NAME env var)")
 	neo4jHTTPAllowUnauthenticatedPing := flag.String("neo4j-http-allow-unauthenticated-ping", "", "Allow unauthenticated ping health checks: true or false (overrides NEO4J_HTTP_ALLOW_UNAUTHENTICATED_PING env var)")
 	neo4jHTTPAllowUnauthenticatedToolsList := flag.String("neo4j-http-allow-unauthenticated-tools-list", "", "Allow unauthenticated tools listing: true or false (overrides NEO4J_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST env var)")
+	neo4jRequestTimeout := flag.String("neo4j-request-timeout", "", "Maximum duration for a single MCP request (overrides NEO4J_MCP_REQUEST_TIMEOUT env var)")
 
 	flag.Parse()
 
@@ -169,6 +174,7 @@ func ParseConfigFlags() *Args {
 		HTTPAllowUnauthenticatedPing:      *neo4jHTTPAllowUnauthenticatedPing,
 		HTTPAllowUnauthenticatedToolsList: *neo4jHTTPAllowUnauthenticatedToolsList,
 		AuthHeaderName:                    *neo4jAuthHeaderName,
+		RequestTimeout:                    *neo4jRequestTimeout,
 	}
 }
 

--- a/internal/cli/args_test.go
+++ b/internal/cli/args_test.go
@@ -324,6 +324,19 @@ func TestHandleArgs(t *testing.T) {
 			expectedExitCode: 1,
 			expectedStderr:   "--neo4j-http-allow-unauthenticated-ping requires a value",
 		},
+		{
+			name:             "neo4j-request-timeout flag with valid value",
+			args:             []string{testProgramName, "--neo4j-request-timeout", "45s"},
+			version:          testVersion,
+			expectedExitCode: -1, // Should not exit, flag is allowed
+		},
+		{
+			name:             "neo4j-request-timeout flag missing value",
+			args:             []string{testProgramName, "--neo4j-request-timeout"},
+			version:          testVersion,
+			expectedExitCode: 1,
+			expectedStderr:   "--neo4j-request-timeout requires a value",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/neo4j/mcp/internal/logger"
 )
@@ -20,6 +21,7 @@ type TransportMode string
 const (
 	// DefaultSchemaSampleSize is the default number of nodes to sample per label when inferring schema
 	DefaultSchemaSampleSize   int32         = 100
+	DefaultRequestTimeout     time.Duration = 3 * time.Minute
 	TransportModeStdio        TransportMode = "stdio"
 	TransportModeHTTP         TransportMode = "http"
 	DeprecatedVariableMessage string        = "Warning: deprecated environment variable \"%s\". Please use: \"%s\" instead\n"
@@ -53,6 +55,7 @@ type Config struct {
 	AuthHeaderName                string        // HTTP header name to read auth credentials from (default: "Authorization")
 	AllowUnauthenticatedPing      bool          // If true, allows unauthenticated ping health checks in HTTP mode
 	AllowUnauthenticatedToolsList bool          // If true, allows unauthenticated tools list in HTTP mode
+	RequestTimeout                time.Duration // Maximum duration for a single MCP request (default: 3m)
 }
 
 // Validate validates the configuration and returns an error if invalid
@@ -64,6 +67,10 @@ func (c *Config) Validate() error {
 	// Default to stdio if not provided (maintains backward compatibility with tests constructing Config directly)
 	if c.TransportMode == "" {
 		c.TransportMode = TransportModeStdio
+	}
+
+	if c.RequestTimeout == 0 {
+		c.RequestTimeout = DefaultRequestTimeout
 	}
 
 	// Validate transport mode
@@ -120,6 +127,10 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	if c.RequestTimeout <= 0 {
+		return fmt.Errorf("invalid request timeout %q: must be a positive duration", c.RequestTimeout)
+	}
+
 	return nil
 }
 
@@ -142,6 +153,7 @@ type CLIOverrides struct {
 	AuthHeaderName                string
 	AllowUnauthenticatedPing      string
 	AllowUnauthenticatedToolsList string
+	RequestTimeout                string
 }
 
 // LoadConfig loads configuration from environment variables, applies CLI overrides, and validates.
@@ -188,6 +200,12 @@ func LoadConfig(cliOverrides *CLIOverrides) (*Config, error) {
 		AllowUnauthenticatedPing:      ParseBool(GetEnv("NEO4J_HTTP_ALLOW_UNAUTHENTICATED_PING"), false),
 		AllowUnauthenticatedToolsList: ParseBool(GetEnv("NEO4J_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST"), false),
 	}
+
+	requestTimeout, err := ParseDuration(GetEnv("NEO4J_MCP_REQUEST_TIMEOUT"), DefaultRequestTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("invalid NEO4J_MCP_REQUEST_TIMEOUT: %w", err)
+	}
+	cfg.RequestTimeout = requestTimeout
 
 	if toolsEnv, ok := os.LookupEnv("NEO4J_MCP_TOOLS"); ok {
 		if toolsEnv == "" {
@@ -248,6 +266,13 @@ func LoadConfig(cliOverrides *CLIOverrides) (*Config, error) {
 		}
 		if cliOverrides.AllowUnauthenticatedToolsList != "" {
 			cfg.AllowUnauthenticatedToolsList = ParseBool(cliOverrides.AllowUnauthenticatedToolsList, false)
+		}
+		if cliOverrides.RequestTimeout != "" {
+			requestTimeout, err := ParseDuration(cliOverrides.RequestTimeout, DefaultRequestTimeout)
+			if err != nil {
+				return nil, fmt.Errorf("invalid --neo4j-request-timeout: %w", err)
+			}
+			cfg.RequestTimeout = requestTimeout
 		}
 	}
 
@@ -334,6 +359,23 @@ func ParseInt32(value string, defaultValue int32) int32 {
 		return defaultValue
 	}
 	return int32(parsed)
+}
+
+// ParseDuration parses a Go duration string (e.g. "30s", "2m").
+// Returns the default value if the string is empty.
+// Returns an error if the value is invalid or non-positive.
+func ParseDuration(value string, defaultValue time.Duration) (time.Duration, error) {
+	if value == "" {
+		return defaultValue, nil
+	}
+	parsed, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", value, err)
+	}
+	if parsed <= 0 {
+		return 0, fmt.Errorf("duration %q must be positive", value)
+	}
+	return parsed, nil
 }
 
 // ParseCommaSeparatedString parses a comma-separated string into a slice of strings.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,8 +20,13 @@ type TransportMode string
 
 const (
 	// DefaultSchemaSampleSize is the default number of nodes to sample per label when inferring schema
-	DefaultSchemaSampleSize   int32         = 100
-	DefaultRequestTimeout     time.Duration = 3 * time.Minute
+	DefaultSchemaSampleSize int32         = 100
+	DefaultRequestTimeout   time.Duration = 3 * time.Minute
+	// MaxRequestTimeout is the largest accepted request timeout. The HTTP server derives
+	// its write and graceful-shutdown timeouts from this value, so leaving it unbounded
+	// would let a single misconfiguration hold connections open indefinitely. The ceiling
+	// is generous enough for long-running GDS workloads.
+	MaxRequestTimeout         time.Duration = 30 * time.Minute
 	TransportModeStdio        TransportMode = "stdio"
 	TransportModeHTTP         TransportMode = "http"
 	DeprecatedVariableMessage string        = "Warning: deprecated environment variable \"%s\". Please use: \"%s\" instead\n"
@@ -129,6 +134,9 @@ func (c *Config) Validate() error {
 
 	if c.RequestTimeout <= 0 {
 		return fmt.Errorf("invalid request timeout %q: must be a positive duration", c.RequestTimeout)
+	}
+	if c.RequestTimeout > MaxRequestTimeout {
+		return fmt.Errorf("invalid request timeout %q: must not exceed %s", c.RequestTimeout, MaxRequestTimeout)
 	}
 
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1128,4 +1128,26 @@ func TestLoadConfig_RequestTimeout(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 20*time.Second, cfg.RequestTimeout)
 	})
+
+	t.Run("at the maximum is accepted", func(t *testing.T) {
+		t.Setenv("NEO4J_MCP_REQUEST_TIMEOUT", MaxRequestTimeout.String())
+
+		cfg, err := LoadConfig(nil)
+		require.NoError(t, err)
+		assert.Equal(t, MaxRequestTimeout, cfg.RequestTimeout)
+	})
+
+	t.Run("above the maximum is rejected from env", func(t *testing.T) {
+		t.Setenv("NEO4J_MCP_REQUEST_TIMEOUT", (MaxRequestTimeout + time.Second).String())
+
+		_, err := LoadConfig(nil)
+		require.ErrorContains(t, err, "must not exceed 30m0s")
+	})
+
+	t.Run("above the maximum is rejected from the CLI flag", func(t *testing.T) {
+		t.Setenv("NEO4J_MCP_REQUEST_TIMEOUT", "")
+
+		_, err := LoadConfig(&CLIOverrides{RequestTimeout: "100h"})
+		require.ErrorContains(t, err, "must not exceed 30m0s")
+	})
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1081,4 +1082,50 @@ func TestLoadConfig_Neo4jMCPToolsCLIOverride(t *testing.T) {
 // newStringPtr returns a new pointer to a string
 func newStringPtr(s string) *string {
 	return &s
+}
+
+func TestLoadConfig_RequestTimeout(t *testing.T) {
+	t.Setenv("NEO4J_TRANSPORT_MODE", "stdio")
+	t.Setenv("NEO4J_URI", "bolt://localhost:7687")
+	t.Setenv("NEO4J_USERNAME", "testuser")
+	t.Setenv("NEO4J_PASSWORD", "testpass")
+	t.Setenv("NEO4J_DATABASE", "neo4j")
+
+	t.Run("default value", func(t *testing.T) {
+		t.Setenv("NEO4J_MCP_REQUEST_TIMEOUT", "")
+
+		cfg, err := LoadConfig(nil)
+		require.NoError(t, err)
+		assert.Equal(t, DefaultRequestTimeout, cfg.RequestTimeout)
+	})
+
+	t.Run("value from env", func(t *testing.T) {
+		t.Setenv("NEO4J_MCP_REQUEST_TIMEOUT", "45s")
+
+		cfg, err := LoadConfig(nil)
+		require.NoError(t, err)
+		assert.Equal(t, 45*time.Second, cfg.RequestTimeout)
+	})
+
+	t.Run("invalid env value", func(t *testing.T) {
+		t.Setenv("NEO4J_MCP_REQUEST_TIMEOUT", "invalid")
+
+		_, err := LoadConfig(nil)
+		require.ErrorContains(t, err, "invalid NEO4J_MCP_REQUEST_TIMEOUT")
+	})
+
+	t.Run("non-positive env value", func(t *testing.T) {
+		t.Setenv("NEO4J_MCP_REQUEST_TIMEOUT", "0s")
+
+		_, err := LoadConfig(nil)
+		require.ErrorContains(t, err, "invalid NEO4J_MCP_REQUEST_TIMEOUT")
+	})
+
+	t.Run("cli override", func(t *testing.T) {
+		t.Setenv("NEO4J_MCP_REQUEST_TIMEOUT", "45s")
+
+		cfg, err := LoadConfig(&CLIOverrides{RequestTimeout: "20s"})
+		require.NoError(t, err)
+		assert.Equal(t, 20*time.Second, cfg.RequestTimeout)
+	})
 }

--- a/internal/mcpcontext/mcpcontext.go
+++ b/internal/mcpcontext/mcpcontext.go
@@ -3,18 +3,22 @@
 
 package mcpcontext
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 type contextKey string
 
 const (
-	basicAuthUserKey contextKey = "basicAuthUser"
-	basicAuthPassKey contextKey = "basicAuthPass"
-	bearerTokenKey   contextKey = "bearerToken"
-	databaseNameKey  contextKey = "databaseName"
-	driverKey        contextKey = "neo4jDriver"
-	readOnlyKey      contextKey = "readOnly"
-	toolsKey         contextKey = "tools"
+	basicAuthUserKey  contextKey = "basicAuthUser"
+	basicAuthPassKey  contextKey = "basicAuthPass"
+	bearerTokenKey    contextKey = "bearerToken"
+	databaseNameKey   contextKey = "databaseName"
+	driverKey         contextKey = "neo4jDriver"
+	readOnlyKey       contextKey = "readOnly"
+	toolsKey          contextKey = "tools"
+	requestTimeoutKey contextKey = "requestTimeout"
 )
 
 // WithDatabaseName adds the target database name to the context
@@ -104,4 +108,19 @@ func GetTools(ctx context.Context) *[]string {
 		return nil
 	}
 	return &tools
+}
+
+// WithRequestTimeout stores the effective request timeout in the context.
+func WithRequestTimeout(ctx context.Context, timeout time.Duration) context.Context {
+	return context.WithValue(ctx, requestTimeoutKey, timeout)
+}
+
+// GetRequestTimeout retrieves the effective request timeout from the context.
+// Returns 0 if the timeout is not set.
+func GetRequestTimeout(ctx context.Context) time.Duration {
+	timeout, ok := ctx.Value(requestTimeoutKey).(time.Duration)
+	if !ok {
+		return 0
+	}
+	return timeout
 }

--- a/internal/server/headers.go
+++ b/internal/server/headers.go
@@ -1,0 +1,11 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+package server
+
+const (
+	uriHeader      = "X-Neo4j-MCP-URI"
+	toolsHeader    = "X-Neo4j-MCP-Tools"
+	readOnlyHeader = "X-Neo4j-MCP-ReadOnly"
+	timeoutHeader  = "X-Neo4j-MCP-Request-Timeout"
+)

--- a/internal/server/headers.go
+++ b/internal/server/headers.go
@@ -3,9 +3,12 @@
 
 package server
 
+// Per-request HTTP headers understood by the Neo4j MCP server. Exported so that tests
+// and other packages reference these constants instead of repeating the wire values,
+// which the compiler cannot connect back to here.
 const (
-	uriHeader      = "X-Neo4j-MCP-URI"
-	toolsHeader    = "X-Neo4j-MCP-Tools"
-	readOnlyHeader = "X-Neo4j-MCP-ReadOnly"
-	timeoutHeader  = "X-Neo4j-MCP-Request-Timeout"
+	URIHeader      = "X-Neo4j-MCP-URI"
+	ToolsHeader    = "X-Neo4j-MCP-Tools"
+	ReadOnlyHeader = "X-Neo4j-MCP-ReadOnly"
+	TimeoutHeader  = "X-Neo4j-MCP-Request-Timeout"
 )

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -213,7 +213,7 @@ func corsMiddleware(allowedOrigins []string, authHeaderName string) func(http.Ha
 			}
 
 			// Build allowed headers list, always including the supported Neo4j MCP headers.
-			allowedHeaders := []string{"Content-Type", "Authorization", uriHeader, toolsHeader, readOnlyHeader, timeoutHeader}
+			allowedHeaders := []string{"Content-Type", "Authorization", URIHeader, ToolsHeader, ReadOnlyHeader, TimeoutHeader}
 			// If a custom auth header is configured, and it's not the default, include it
 			if authHeaderName != "" && !strings.EqualFold(authHeaderName, "Authorization") {
 				allowedHeaders = append(allowedHeaders, authHeaderName)
@@ -266,10 +266,10 @@ func readOnlyMiddleware() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// r.Header.Values is used to distinguish when the header is not set
-			vals := r.Header.Values(readOnlyHeader)
+			vals := r.Header.Values(ReadOnlyHeader)
 
 			if len(vals) > 1 {
-				http.Error(w, "Bad Request: duplicate X-Neo4j-MCP-ReadOnly header found", http.StatusBadRequest)
+				http.Error(w, fmt.Sprintf("Bad Request: duplicate %s header found", ReadOnlyHeader), http.StatusBadRequest)
 				return
 			}
 			if len(vals) == 1 {
@@ -280,7 +280,7 @@ func readOnlyMiddleware() func(http.Handler) http.Handler {
 				case "true":
 					readOnly = true
 				default:
-					http.Error(w, `Bad Request: "X-Neo4j-MCP-ReadOnly" must be "true" or "false"`, http.StatusBadRequest)
+					http.Error(w, fmt.Sprintf(`Bad Request: %q must be "true" or "false"`, ReadOnlyHeader), http.StatusBadRequest)
 					return
 				}
 				ctx := mcpcontext.WithReadOnly(r.Context(), readOnly)
@@ -301,9 +301,9 @@ func toolsMiddleware() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// r.Header.Values is used to distinguish when the header is not set
-			vals := r.Header.Values(toolsHeader)
+			vals := r.Header.Values(ToolsHeader)
 			if len(vals) > 1 {
-				http.Error(w, "Bad Request: duplicate X-Neo4j-MCP-Tools header found", http.StatusBadRequest)
+				http.Error(w, fmt.Sprintf("Bad Request: duplicate %s header found", ToolsHeader), http.StatusBadRequest)
 				return
 			}
 			if len(vals) == 1 {
@@ -333,7 +333,7 @@ func toolsMiddleware() func(http.Handler) http.Handler {
 func timeoutMiddleware(maxTimeout time.Duration) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			effectiveTimeout, err := resolveRequestTimeout(maxTimeout, r.Header.Values(timeoutHeader))
+			effectiveTimeout, err := resolveRequestTimeout(maxTimeout, r.Header.Values(TimeoutHeader))
 			if err != nil {
 				http.Error(w, "Bad Request: "+err.Error(), http.StatusBadRequest)
 				return
@@ -349,7 +349,7 @@ func timeoutMiddleware(maxTimeout time.Duration) func(http.Handler) http.Handler
 // maximum and an optional per-request header value.
 func resolveRequestTimeout(maxTimeout time.Duration, headerValues []string) (time.Duration, error) {
 	if len(headerValues) > 1 {
-		return 0, fmt.Errorf("duplicate %s header found", timeoutHeader)
+		return 0, fmt.Errorf("duplicate %s header found", TimeoutHeader)
 	}
 	if len(headerValues) == 0 {
 		return maxTimeout, nil
@@ -357,13 +357,13 @@ func resolveRequestTimeout(maxTimeout time.Duration, headerValues []string) (tim
 
 	requested, err := time.ParseDuration(strings.TrimSpace(headerValues[0]))
 	if err != nil {
-		return 0, fmt.Errorf("%q must be a valid duration (e.g. \"30s\", \"2m\")", timeoutHeader)
+		return 0, fmt.Errorf("%q must be a valid duration (e.g. \"30s\", \"2m\")", TimeoutHeader)
 	}
 	if requested <= 0 {
-		return 0, fmt.Errorf("%q must be a positive duration", timeoutHeader)
+		return 0, fmt.Errorf("%q must be a positive duration", TimeoutHeader)
 	}
 	if requested > maxTimeout {
-		return 0, fmt.Errorf("%q (%s) exceeds server maximum (%s)", timeoutHeader, requested, maxTimeout)
+		return 0, fmt.Errorf("%q (%s) exceeds server maximum (%s)", TimeoutHeader, requested, maxTimeout)
 	}
 
 	return requested, nil

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/neo4j/mcp/internal/config"
 	"github.com/neo4j/mcp/internal/database"
@@ -53,6 +54,7 @@ func (s *Neo4jMCPServer) chainMiddleware(allowedOrigins []string, next http.Hand
 	handler = pathValidationMiddleware()(handler)
 	handler = readOnlyMiddleware()(handler)
 	handler = toolsMiddleware()(handler)
+	handler = timeoutMiddleware(effectiveRequestTimeout(s.config))(handler)
 
 	return handler
 }
@@ -210,8 +212,8 @@ func corsMiddleware(allowedOrigins []string, authHeaderName string) func(http.Ha
 				w.Header().Set("Access-Control-Allow-Origin", origin)
 			}
 
-			// Build allowed headers list, always include Content-Type, Authorization, and X-Neo4j-MCP-URI.
-			allowedHeaders := []string{"Content-Type", "Authorization", uriHeader}
+			// Build allowed headers list, always including the supported Neo4j MCP headers.
+			allowedHeaders := []string{"Content-Type", "Authorization", uriHeader, toolsHeader, readOnlyHeader, timeoutHeader}
 			// If a custom auth header is configured, and it's not the default, include it
 			if authHeaderName != "" && !strings.EqualFold(authHeaderName, "Authorization") {
 				allowedHeaders = append(allowedHeaders, authHeaderName)
@@ -264,7 +266,7 @@ func readOnlyMiddleware() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// r.Header.Values is used to distinguish when the header is not set
-			vals := r.Header.Values("X-Neo4j-MCP-ReadOnly")
+			vals := r.Header.Values(readOnlyHeader)
 
 			if len(vals) > 1 {
 				http.Error(w, "Bad Request: duplicate X-Neo4j-MCP-ReadOnly header found", http.StatusBadRequest)
@@ -299,7 +301,7 @@ func toolsMiddleware() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// r.Header.Values is used to distinguish when the header is not set
-			vals := r.Header.Values("X-Neo4j-MCP-Tools")
+			vals := r.Header.Values(toolsHeader)
 			if len(vals) > 1 {
 				http.Error(w, "Bad Request: duplicate X-Neo4j-MCP-Tools header found", http.StatusBadRequest)
 				return
@@ -325,6 +327,46 @@ func toolsMiddleware() func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// timeoutMiddleware resolves the effective request timeout from HTTP headers.
+func timeoutMiddleware(maxTimeout time.Duration) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			effectiveTimeout, err := resolveRequestTimeout(maxTimeout, r.Header.Values(timeoutHeader))
+			if err != nil {
+				http.Error(w, "Bad Request: "+err.Error(), http.StatusBadRequest)
+				return
+			}
+
+			ctx := mcpcontext.WithRequestTimeout(r.Context(), effectiveTimeout)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// resolveRequestTimeout determines the effective request timeout from the server
+// maximum and an optional per-request header value.
+func resolveRequestTimeout(maxTimeout time.Duration, headerValues []string) (time.Duration, error) {
+	if len(headerValues) > 1 {
+		return 0, fmt.Errorf("duplicate %s header found", timeoutHeader)
+	}
+	if len(headerValues) == 0 {
+		return maxTimeout, nil
+	}
+
+	requested, err := time.ParseDuration(strings.TrimSpace(headerValues[0]))
+	if err != nil {
+		return 0, fmt.Errorf("%q must be a valid duration (e.g. \"30s\", \"2m\")", timeoutHeader)
+	}
+	if requested <= 0 {
+		return 0, fmt.Errorf("%q must be a positive duration", timeoutHeader)
+	}
+	if requested > maxTimeout {
+		return 0, fmt.Errorf("%q (%s) exceeds server maximum (%s)", timeoutHeader, requested, maxTimeout)
+	}
+
+	return requested, nil
 }
 
 // dbNameMiddleware extracts and validates the database name from the URL path,

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/server"
 	analytics_mocks "github.com/neo4j/mcp/internal/analytics/mocks"
@@ -396,8 +397,9 @@ func TestCORSMiddleware_PreflightRequest(t *testing.T) {
 		t.Error("Expected Access-Control-Allow-Methods header to be set")
 	}
 
-	if rec.Header().Get("Access-Control-Allow-Headers") != "Content-Type, Authorization, X-Neo4j-MCP-URI, X-Auth" {
-		t.Errorf("Expected Access-Control-Allow-Headers to include X-Neo4j-MCP-URI, got: %q", rec.Header().Get("Access-Control-Allow-Headers"))
+	expectedAllowedHeaders := strings.Join([]string{"Content-Type", "Authorization", uriHeader, toolsHeader, readOnlyHeader, timeoutHeader, "X-Auth"}, ", ")
+	if rec.Header().Get("Access-Control-Allow-Headers") != expectedAllowedHeaders {
+		t.Errorf("Expected Access-Control-Allow-Headers %q, got: %q", expectedAllowedHeaders, rec.Header().Get("Access-Control-Allow-Headers"))
 	}
 
 	if rec.Header().Get("Access-Control-Max-Age") != corsMaxAgeSeconds {
@@ -1078,6 +1080,114 @@ func TestToolsMiddleware(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveRequestTimeout(t *testing.T) {
+	maxTimeout := 60 * time.Second
+
+	tests := []struct {
+		name        string
+		header      []string
+		want        time.Duration
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:   "no header uses server maximum",
+			header: nil,
+			want:   maxTimeout,
+		},
+		{
+			name:   "valid header below maximum",
+			header: []string{"30s"},
+			want:   30 * time.Second,
+		},
+		{
+			name:        "duplicate header",
+			header:      []string{"30s", "20s"},
+			wantErr:     true,
+			errContains: "duplicate",
+		},
+		{
+			name:        "invalid duration",
+			header:      []string{"not-a-duration"},
+			wantErr:     true,
+			errContains: "must be a valid duration",
+		},
+		{
+			name:        "non-positive duration",
+			header:      []string{"0s"},
+			wantErr:     true,
+			errContains: "positive duration",
+		},
+		{
+			name:        "exceeds server maximum",
+			header:      []string{"90s"},
+			wantErr:     true,
+			errContains: "exceeds server maximum",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveRequestTimeout(maxTimeout, tt.header)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("resolveRequestTimeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTimeoutMiddleware(t *testing.T) {
+	maxTimeout := 2 * time.Second
+
+	t.Run("stores request timeout in context without deadline", func(t *testing.T) {
+		handler := timeoutMiddleware(maxTimeout)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if _, ok := r.Context().Deadline(); ok {
+				t.Fatal("expected request context to not have a deadline")
+			}
+			if got := mcpcontext.GetRequestTimeout(r.Context()); got != maxTimeout {
+				t.Fatalf("GetRequestTimeout() = %v, want %v", got, maxTimeout)
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("rejects timeout above server maximum", func(t *testing.T) {
+		handler := timeoutMiddleware(maxTimeout)(mockHandler())
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set(timeoutHeader, "5s")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected status 400, got %d", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "exceeds server maximum") {
+			t.Fatalf("expected exceeds server maximum error, got %q", rec.Body.String())
+		}
+	})
 }
 
 type stubURIResolver struct {

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -6,6 +6,7 @@ package server
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -397,7 +398,7 @@ func TestCORSMiddleware_PreflightRequest(t *testing.T) {
 		t.Error("Expected Access-Control-Allow-Methods header to be set")
 	}
 
-	expectedAllowedHeaders := strings.Join([]string{"Content-Type", "Authorization", uriHeader, toolsHeader, readOnlyHeader, timeoutHeader, "X-Auth"}, ", ")
+	expectedAllowedHeaders := strings.Join([]string{"Content-Type", "Authorization", URIHeader, ToolsHeader, ReadOnlyHeader, TimeoutHeader, "X-Auth"}, ", ")
 	if rec.Header().Get("Access-Control-Allow-Headers") != expectedAllowedHeaders {
 		t.Errorf("Expected Access-Control-Allow-Headers %q, got: %q", expectedAllowedHeaders, rec.Header().Get("Access-Control-Allow-Headers"))
 	}
@@ -837,7 +838,7 @@ func TestNeo4jDriverMiddleware_ErrorPaths(t *testing.T) {
 	}{
 		{
 			name:     "resolver error returns 400",
-			resolver: &stubURIResolver{err: errors.New("missing required header X-Neo4j-MCP-URI")},
+			resolver: &stubURIResolver{err: fmt.Errorf("missing required header %s", URIHeader)},
 			registry: &stubDriverRegistry{},
 		},
 		{
@@ -947,7 +948,7 @@ func TestReadOnlyMiddleware(t *testing.T) {
 
 			req := httptest.NewRequest(http.MethodPost, "/db/testdb/mcp", nil)
 			if tt.setHeader {
-				req.Header.Set("X-Neo4j-MCP-ReadOnly", tt.headerValue)
+				req.Header.Set(ReadOnlyHeader, tt.headerValue)
 			}
 			rec := httptest.NewRecorder()
 
@@ -1063,7 +1064,7 @@ func TestToolsMiddleware(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "/db/testdb/mcp", nil)
 			if tt.setHeader {
 				for _, v := range tt.headerValues {
-					req.Header.Add("X-Neo4j-MCP-Tools", v)
+					req.Header.Add(ToolsHeader, v)
 				}
 			}
 			rec := httptest.NewRecorder()
@@ -1183,7 +1184,7 @@ func TestTimeoutMiddleware(t *testing.T) {
 		handler := timeoutMiddleware(maxTimeout)(mockHandler())
 
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
-		req.Header.Set(timeoutHeader, "5s")
+		req.Header.Set(TimeoutHeader, "5s")
 		rec := httptest.NewRecorder()
 		handler.ServeHTTP(rec, req)
 

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -1121,6 +1121,12 @@ func TestResolveRequestTimeout(t *testing.T) {
 			errContains: "positive duration",
 		},
 		{
+			name:        "negative duration",
+			header:      []string{"-1s"},
+			wantErr:     true,
+			errContains: "positive duration",
+		},
+		{
 			name:        "exceeds server maximum",
 			header:      []string{"90s"},
 			wantErr:     true,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -142,9 +142,6 @@ func NewNeo4jMCPServer(version string, cfg *config.Config, dbService database.Se
 				if isRequestDeadlineExceeded(ctx, err) {
 					return mcp.NewToolResultError(formatRequestTimeoutError(ctx)), nil
 				}
-				if result != nil && result.IsError && isRequestDeadlineExceeded(ctx, nil) {
-					return mcp.NewToolResultError(formatRequestTimeoutError(ctx)), nil
-				}
 
 				return result, err
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -29,11 +30,11 @@ import (
 const (
 	protocolHTTP                = "http"
 	protocolHTTPS               = "https"
-	serverHTTPShutdownTimeout   = 65 * time.Second  // Timeout for graceful shutdown (must exceed WriteTimeout to allow active requests to complete)
 	serverHTTPReadHeaderTimeout = 5 * time.Second   // SECURITY: Maximum time to read request headers (prevents Slowloris attacks)
 	serverHTTPReadTimeout       = 15 * time.Second  // SECURITY: Maximum time to read entire request including body (prevents slow-read attacks)
-	serverHTTPWriteTimeout      = 60 * time.Second  // FUNCTIONALITY: Maximum time to write response (allows complex Neo4j queries and large result sets)
 	serverHTTPIdleTimeout       = 120 * time.Second // PERFORMANCE: Maximum time to keep idle keep-alive connections open (improves connection reuse)
+	httpWriteTimeoutGrace       = 5 * time.Second   // Buffer added to WriteTimeout so timeout error responses can be written
+	httpShutdownGrace           = 5 * time.Second   // Buffer added to shutdown timeout so active requests can complete
 )
 
 // Neo4jMCPServer represents the MCP server instance
@@ -100,6 +101,13 @@ func NewNeo4jMCPServer(version string, cfg *config.Config, dbService database.Se
 		server.WithToolHandlerMiddleware(func(next server.ToolHandlerFunc) server.ToolHandlerFunc {
 			// WithToolFilter controls tool advertisement; this middleware enforces execution
 			return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				timeout := mcpcontext.GetRequestTimeout(ctx)
+				if timeout <= 0 {
+					timeout = effectiveRequestTimeout(cfg)
+				}
+				ctx, cancel := context.WithTimeout(ctx, timeout)
+				defer cancel()
+
 				// Guards are checked read-only first, then the configured tools list.
 				// When a request violates both, the read-only error takes precedence.
 				readOnly := mcpcontext.GetReadOnly(ctx)
@@ -129,7 +137,15 @@ func NewNeo4jMCPServer(version string, cfg *config.Config, dbService database.Se
 					return mcp.NewToolResultError(fmt.Sprintf("'%s' is not in the list of configured tools", req.Params.Name)), nil
 				}
 
-				return next(ctx, req)
+				result, err := next(ctx, req)
+				if isRequestDeadlineExceeded(ctx, err) {
+					return mcp.NewToolResultError(formatRequestTimeoutError(ctx)), nil
+				}
+				if result != nil && result.IsError && isRequestDeadlineExceeded(ctx, nil) {
+					return mcp.NewToolResultError(formatRequestTimeoutError(ctx)), nil
+				}
+
+				return result, err
 			}
 		}),
 	)
@@ -406,6 +422,8 @@ func (s *Neo4jMCPServer) StartHTTPServer() error {
 	)
 
 	allowedOrigins := parseAllowedOrigins(s.config.HTTPAllowedOrigins)
+	writeTimeout := effectiveRequestTimeout(s.config) + httpWriteTimeoutGrace
+	shutdownTimeout := writeTimeout + httpShutdownGrace
 
 	// Route /healthz directly (no auth required).
 	// All other paths go through the full middleware chain which enforces auth and path validation.
@@ -419,7 +437,7 @@ func (s *Neo4jMCPServer) StartHTTPServer() error {
 		Handler: mux,
 		// Timeouts optimized for stateless HTTP MCP requests
 		ReadTimeout:       serverHTTPReadTimeout,
-		WriteTimeout:      serverHTTPWriteTimeout,
+		WriteTimeout:      writeTimeout,
 		IdleTimeout:       serverHTTPIdleTimeout,
 		ReadHeaderTimeout: serverHTTPReadHeaderTimeout,
 	}
@@ -462,7 +480,7 @@ func (s *Neo4jMCPServer) StartHTTPServer() error {
 	select {
 	case sig := <-sigChan:
 		slog.Info("Shutdown signal received", "signal", sig.String())
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), serverHTTPShutdownTimeout)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer cancel()
 		if err := s.httpServer.Shutdown(shutdownCtx); err != nil {
 			slog.Error("Error during server shutdown", "error", err)
@@ -500,8 +518,18 @@ func (s *Neo4jMCPServer) onRequestInitialization(ctx context.Context, _ any, mes
 		return nil
 	}
 
+	timeout := mcpcontext.GetRequestTimeout(ctx)
+	if timeout <= 0 {
+		timeout = effectiveRequestTimeout(s.config)
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	slog.Info("Initialize request: verifying requirements...")
 	if err := s.verifyRequirements(ctx); err != nil {
+		if isRequestDeadlineExceeded(ctx, err) {
+			return errors.New(formatRequestTimeoutError(ctx))
+		}
 		return err
 	}
 	s.emitConnectionInitializedEvent(ctx)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -104,6 +104,7 @@ func NewNeo4jMCPServer(version string, cfg *config.Config, dbService database.Se
 				timeout := mcpcontext.GetRequestTimeout(ctx)
 				if timeout <= 0 {
 					timeout = effectiveRequestTimeout(cfg)
+					ctx = mcpcontext.WithRequestTimeout(ctx, timeout)
 				}
 				ctx, cancel := context.WithTimeout(ctx, timeout)
 				defer cancel()
@@ -521,6 +522,7 @@ func (s *Neo4jMCPServer) onRequestInitialization(ctx context.Context, _ any, mes
 	timeout := mcpcontext.GetRequestTimeout(ctx)
 	if timeout <= 0 {
 		timeout = effectiveRequestTimeout(s.config)
+		ctx = mcpcontext.WithRequestTimeout(ctx, timeout)
 	}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/server/server_http_lifecycle_test.go
+++ b/internal/server/server_http_lifecycle_test.go
@@ -180,7 +180,7 @@ func TestNeo4jMCPServerHTTPMode(t *testing.T) {
 		s, errChan := createHTTPServer(t, cfg, mockDB, analyticsService)
 
 		headers := defaultHeaders()
-		headers["X-Neo4j-MCP-Tools"] = "read-cypher, get-schema"
+		headers[server.ToolsHeader] = "read-cypher, get-schema"
 		mcpClient := createStreamableHTTPClient(uri, headers)
 
 		_, err := mcpClient.Initialize(context.Background(), mcp.InitializeRequest{})
@@ -217,7 +217,7 @@ func TestNeo4jMCPServerHTTPMode(t *testing.T) {
 		s, errChan := createHTTPServer(t, cfg, mockDB, analyticsService)
 
 		headers := defaultHeaders()
-		headers["X-Neo4j-MCP-Tools"] = "read-cypher, list-gds-procedures"
+		headers[server.ToolsHeader] = "read-cypher, list-gds-procedures"
 		mcpClient := createStreamableHTTPClient(uri, headers)
 
 		_, err := mcpClient.Initialize(context.Background(), mcp.InitializeRequest{})
@@ -346,57 +346,57 @@ func TestNeo4jMCPServerHTTPModeToolsFilter(t *testing.T) {
 	}{
 		{
 			name:          "All tools returned when X-Neo4j-MCP-ReadOnly is false",
-			extraHeaders:  map[string]string{"X-Neo4j-MCP-ReadOnly": "false"},
+			extraHeaders:  map[string]string{server.ReadOnlyHeader: "false"},
 			wantToolNames: []string{"get-schema", "list-gds-procedures", "read-cypher", "write-cypher"},
 		},
 		{
 			name:          "All tools returned when X-Neo4j-MCP-ReadOnly is False (mixed case)",
-			extraHeaders:  map[string]string{"X-Neo4j-MCP-ReadOnly": "False"},
+			extraHeaders:  map[string]string{server.ReadOnlyHeader: "False"},
 			wantToolNames: []string{"get-schema", "list-gds-procedures", "read-cypher", "write-cypher"},
 		},
 		{
 			name:          "Only read-only tools returned when X-Neo4j-MCP-ReadOnly is true",
-			extraHeaders:  map[string]string{"X-Neo4j-MCP-ReadOnly": "true"},
+			extraHeaders:  map[string]string{server.ReadOnlyHeader: "true"},
 			wantToolNames: []string{"get-schema", "list-gds-procedures", "read-cypher"},
 		},
 		{
 			name:         "Error when X-Neo4j-MCP-ReadOnly contains an invalid value",
-			extraHeaders: map[string]string{"X-Neo4j-MCP-ReadOnly": "invalid"},
+			extraHeaders: map[string]string{server.ReadOnlyHeader: "invalid"},
 			wantErr:      true,
 		},
 		{
 			name:          "Single tool filter via X-Neo4j-MCP-Tools",
-			extraHeaders:  map[string]string{"X-Neo4j-MCP-Tools": "read-cypher"},
+			extraHeaders:  map[string]string{server.ToolsHeader: "read-cypher"},
 			wantToolNames: []string{"read-cypher"},
 		},
 		{
 			name:          "Comma-separated tools via X-Neo4j-MCP-Tools",
-			extraHeaders:  map[string]string{"X-Neo4j-MCP-Tools": "read-cypher, write-cypher"},
+			extraHeaders:  map[string]string{server.ToolsHeader: "read-cypher, write-cypher"},
 			wantToolNames: []string{"read-cypher", "write-cypher"},
 		},
 		{
 			// mcp-go wraps 400 errors: "server returned 4xx for initialize POST, likely a legacy SSE server"
 			name:         "Error when X-Neo4j-MCP-Tools contains an invalid tool name",
-			extraHeaders: map[string]string{"X-Neo4j-MCP-Tools": "batman-tool"},
+			extraHeaders: map[string]string{server.ToolsHeader: "batman-tool"},
 			wantErr:      true,
 		},
 		{
 			// mcp-go wraps 400 errors: "server returned 4xx for initialize POST, likely a legacy SSE server"
 			name:         "Error when X-Neo4j-MCP-Tools contains an mixed valid tool names",
-			extraHeaders: map[string]string{"X-Neo4j-MCP-Tools": "read-cypher, batman-tool"},
+			extraHeaders: map[string]string{server.ToolsHeader: "read-cypher, batman-tool"},
 			wantErr:      true,
 		},
 		{
 			// mcp-go wraps 400 errors: "server returned 4xx for initialize POST, likely a legacy SSE server"
 			name:         "Error when X-Neo4j-MCP-Tools is set as empty \"\" string",
-			extraHeaders: map[string]string{"X-Neo4j-MCP-Tools": ""},
+			extraHeaders: map[string]string{server.ToolsHeader: ""},
 			wantErr:      true,
 		},
 		{
 			name: "X-Neo4j-MCP-Tools and X-Neo4j-MCP-ReadOnly applied as intersection",
 			extraHeaders: map[string]string{
-				"X-Neo4j-MCP-Tools":    "read-cypher, write-cypher",
-				"X-Neo4j-MCP-ReadOnly": "true",
+				server.ToolsHeader:    "read-cypher, write-cypher",
+				server.ReadOnlyHeader: "true",
 			},
 			// write-cypher is not read-only, so it is excluded despite being in the tools list
 			wantToolNames: []string{"read-cypher"},
@@ -491,8 +491,8 @@ func assertNoCloseOrStopError(t *testing.T, s *server.Neo4jMCPServer, errChan ch
 // defaultHeaders returns the base request headers used by most test clients.
 func defaultHeaders() map[string]string {
 	return map[string]string{
-		"Authorization":   "Basic bmVvNGo6cGFzc3dvcmQ=",
-		"X-Neo4j-MCP-URI": "bolt://test-host:7687",
+		"Authorization":  "Basic bmVvNGo6cGFzc3dvcmQ=",
+		server.URIHeader: "bolt://test-host:7687",
 	}
 }
 

--- a/internal/server/server_http_test.go
+++ b/internal/server/server_http_test.go
@@ -173,12 +173,6 @@ func TestHTTPServerTimeoutConstants(t *testing.T) {
 			description:   "Should be 15s to prevent slow-read attacks",
 		},
 		{
-			name:          "WriteTimeout",
-			actualValue:   serverHTTPWriteTimeout,
-			expectedValue: 60 * time.Second,
-			description:   "Should be 60s to allow complex Neo4j queries",
-		},
-		{
 			name:          "IdleTimeout",
 			actualValue:   serverHTTPIdleTimeout,
 			expectedValue: 120 * time.Second,

--- a/internal/server/timeout.go
+++ b/internal/server/timeout.go
@@ -27,6 +27,7 @@ func formatRequestTimeoutError(ctx context.Context) string {
 	return "request timed out"
 }
 
+// isRequestDeadlineExceeded reports whether the request budget expired.
 func isRequestDeadlineExceeded(ctx context.Context, err error) bool {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return true

--- a/internal/server/timeout.go
+++ b/internal/server/timeout.go
@@ -1,0 +1,35 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/neo4j/mcp/internal/config"
+	"github.com/neo4j/mcp/internal/mcpcontext"
+)
+
+func effectiveRequestTimeout(cfg *config.Config) time.Duration {
+	if cfg == nil || cfg.RequestTimeout <= 0 {
+		return config.DefaultRequestTimeout
+	}
+	return cfg.RequestTimeout
+}
+
+func formatRequestTimeoutError(ctx context.Context) string {
+	if timeout := mcpcontext.GetRequestTimeout(ctx); timeout > 0 {
+		return fmt.Sprintf("request timed out after %s", timeout)
+	}
+	return "request timed out"
+}
+
+func isRequestDeadlineExceeded(ctx context.Context, err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	return ctx.Err() == context.DeadlineExceeded
+}

--- a/internal/server/timeout_test.go
+++ b/internal/server/timeout_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/neo4j/mcp/internal/config"
 	"github.com/neo4j/mcp/internal/mcpcontext"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEffectiveRequestTimeout(t *testing.T) {
@@ -60,5 +61,19 @@ func TestIsRequestDeadlineExceeded(t *testing.T) {
 
 	t.Run("false for other errors", func(t *testing.T) {
 		assert.False(t, isRequestDeadlineExceeded(context.Background(), errors.New("boom")))
+	})
+
+	t.Run("false when only a nested deadline expired", func(t *testing.T) {
+		// verifyRequirements probes connectivity under a shorter deadline. When that one
+		// expires the request still has budget left, so the underlying error must be
+		// reported instead of a request timeout.
+		ctx, cancelRequest := context.WithTimeout(context.Background(), time.Minute)
+		defer cancelRequest()
+		nested, cancelNested := context.WithTimeout(ctx, time.Nanosecond)
+		defer cancelNested()
+		time.Sleep(time.Millisecond)
+
+		require.Equal(t, context.DeadlineExceeded, nested.Err())
+		assert.False(t, isRequestDeadlineExceeded(ctx, nil))
 	})
 }

--- a/internal/server/timeout_test.go
+++ b/internal/server/timeout_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/neo4j/mcp/internal/config"
+	"github.com/neo4j/mcp/internal/mcpcontext"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEffectiveRequestTimeout(t *testing.T) {
+	t.Run("nil config falls back to default", func(t *testing.T) {
+		assert.Equal(t, config.DefaultRequestTimeout, effectiveRequestTimeout(nil))
+	})
+
+	t.Run("zero timeout falls back to default", func(t *testing.T) {
+		assert.Equal(t, config.DefaultRequestTimeout, effectiveRequestTimeout(&config.Config{}))
+	})
+
+	t.Run("configured timeout is used", func(t *testing.T) {
+		cfg := &config.Config{RequestTimeout: 42 * time.Second}
+		assert.Equal(t, 42*time.Second, effectiveRequestTimeout(cfg))
+	})
+}
+
+func TestFormatRequestTimeoutError(t *testing.T) {
+	t.Run("includes stored timeout", func(t *testing.T) {
+		ctx := mcpcontext.WithRequestTimeout(context.Background(), 30*time.Second)
+		assert.Equal(t, "request timed out after 30s", formatRequestTimeoutError(ctx))
+	})
+
+	t.Run("generic message without stored timeout", func(t *testing.T) {
+		assert.Equal(t, "request timed out", formatRequestTimeoutError(context.Background()))
+	})
+}
+
+func TestIsRequestDeadlineExceeded(t *testing.T) {
+	t.Run("true for deadline exceeded error", func(t *testing.T) {
+		assert.True(t, isRequestDeadlineExceeded(context.Background(), context.DeadlineExceeded))
+	})
+
+	t.Run("true for expired context", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+		defer cancel()
+		time.Sleep(time.Millisecond)
+		assert.True(t, isRequestDeadlineExceeded(ctx, nil))
+	})
+
+	t.Run("false for plain cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		assert.False(t, isRequestDeadlineExceeded(ctx, nil))
+	})
+
+	t.Run("false for other errors", func(t *testing.T) {
+		assert.False(t, isRequestDeadlineExceeded(context.Background(), errors.New("boom")))
+	})
+}

--- a/internal/server/uri_resolver.go
+++ b/internal/server/uri_resolver.go
@@ -28,18 +28,18 @@ type URIResolver interface {
 type HeaderURIResolver struct{}
 
 func (h *HeaderURIResolver) Resolve(r *http.Request) (string, error) {
-	raw := r.Header.Get(uriHeader)
+	raw := r.Header.Get(URIHeader)
 	if raw == "" {
-		return "", fmt.Errorf("missing required header %s", uriHeader)
+		return "", fmt.Errorf("missing required header %s", URIHeader)
 	}
 
 	parsed, err := url.Parse(raw)
 	if err != nil {
-		return "", fmt.Errorf("invalid URI in header %s: %v", uriHeader, err)
+		return "", fmt.Errorf("invalid URI in header %s: %v", URIHeader, err)
 	}
 
 	if !allowedBoltSchemes[parsed.Scheme] {
-		return "", fmt.Errorf("invalid URI in header %s: scheme must be one of bolt, bolt+s, bolt+ssc, neo4j, neo4j+s, neo4j+ssc", uriHeader)
+		return "", fmt.Errorf("invalid URI in header %s: scheme must be one of bolt, bolt+s, bolt+ssc, neo4j, neo4j+s, neo4j+ssc", URIHeader)
 	}
 
 	return raw, nil

--- a/internal/server/uri_resolver.go
+++ b/internal/server/uri_resolver.go
@@ -9,8 +9,6 @@ import (
 	"net/url"
 )
 
-const uriHeader = "X-Neo4j-MCP-URI"
-
 // allowedBoltSchemes is the set of URI schemes accepted in header
 var allowedBoltSchemes = map[string]bool{
 	"bolt":      true,

--- a/internal/server/uri_resolver_test.go
+++ b/internal/server/uri_resolver_test.go
@@ -4,6 +4,7 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,7 +16,8 @@ import (
 func TestHeaderURIResolver_Resolve(t *testing.T) {
 	resolver := &HeaderURIResolver{}
 
-	invalidURIErrMsg := "invalid URI in header X-Neo4j-MCP-URI: scheme must be one of bolt, bolt+s, bolt+ssc, neo4j, neo4j+s, neo4j+ssc"
+	invalidURIErrMsg := fmt.Sprintf("invalid URI in header %s: scheme must be one of bolt, bolt+s, bolt+ssc, neo4j, neo4j+s, neo4j+ssc", URIHeader)
+	missingURIErrMsg := fmt.Sprintf("missing required header %s", URIHeader)
 
 	tests := []struct {
 		name      string
@@ -68,13 +70,13 @@ func TestHeaderURIResolver_Resolve(t *testing.T) {
 		},
 		{
 			name:    "absent header returns error",
-			wantErr: "missing required header X-Neo4j-MCP-URI",
+			wantErr: missingURIErrMsg,
 		},
 		{
 			name:      "empty header value returns error",
 			setHeader: true,
 			header:    "",
-			wantErr:   "missing required header X-Neo4j-MCP-URI",
+			wantErr:   missingURIErrMsg,
 		},
 		{
 			name:      "http scheme rejected",
@@ -94,7 +96,7 @@ func TestHeaderURIResolver_Resolve(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodPost, "/db/neo4j/mcp", nil)
 			if tt.setHeader {
-				req.Header.Set(uriHeader, tt.header)
+				req.Header.Set(URIHeader, tt.header)
 			}
 
 			got, err := resolver.Resolve(req)

--- a/manifest.json
+++ b/manifest.json
@@ -73,6 +73,13 @@
       "description": "Number of nodes to sample for schema inference",
       "required": false,
       "sensitive": false
+    },
+    "NEO4J_MCP_REQUEST_TIMEOUT": {
+      "type": "string",
+      "title": "Request timeout",
+      "description": "Maximum duration for a single MCP request (e.g., 30s, 2m)",
+      "required": false,
+      "sensitive": false
     }
   },
   "server": {
@@ -89,7 +96,8 @@
         "NEO4J_TELEMETRY": "${user_config.NEO4J_TELEMETRY}",
         "NEO4J_LOG_LEVEL": "${user_config.NEO4J_LOG_LEVEL}",
         "NEO4J_LOG_FORMAT": "${user_config.NEO4J_LOG_FORMAT}",
-        "NEO4J_SCHEMA_SAMPLE_SIZE": "${user_config.NEO4J_SCHEMA_SAMPLE_SIZE}"
+        "NEO4J_SCHEMA_SAMPLE_SIZE": "${user_config.NEO4J_SCHEMA_SAMPLE_SIZE}",
+        "NEO4J_MCP_REQUEST_TIMEOUT": "${user_config.NEO4J_MCP_REQUEST_TIMEOUT}"
       }
     }
   },

--- a/manifest.json
+++ b/manifest.json
@@ -77,7 +77,7 @@
     "NEO4J_MCP_REQUEST_TIMEOUT": {
       "type": "string",
       "title": "Request timeout",
-      "description": "Maximum duration for a single MCP request (e.g., 30s, 2m)",
+      "description": "Maximum duration for a single MCP request, up to 30m (e.g., 30s, 2m)",
       "required": false,
       "sensitive": false
     }

--- a/test/e2e/http_server_helpers_test.go
+++ b/test/e2e/http_server_helpers_test.go
@@ -28,7 +28,8 @@ import (
 // startHTTPModeServer launches the server binary in HTTP mode on a random free port.
 // It polls /healthz until the server is ready and returns the base URL.
 // The server process is automatically terminated when the test ends.
-func startHTTPModeServer(t *testing.T) string {
+// extraArgs are appended to the server command line (e.g. "--neo4j-request-timeout", "5s").
+func startHTTPModeServer(t *testing.T, extraArgs ...string) string {
 	t.Helper()
 
 	port, err := freePort()
@@ -40,12 +41,13 @@ func startHTTPModeServer(t *testing.T) string {
 	// NEO4J_DATABASE — the URI, credentials, and database are supplied per-request via the
 	// X-Neo4j-MCP-URI header, Auth headers, and URL path respectively.
 	// Strip those keys so any locally-set env values don't cause a startup validation error.
-	cmd := exec.Command(server, // #nosec G204 -- server is a binary path built by the test harness, not user input
+	args := append([]string{
 		"--neo4j-transport-mode", "http",
 		"--neo4j-http-host", "127.0.0.1",
 		"--neo4j-http-port", fmt.Sprintf("%d", port),
 		"--neo4j-telemetry", "false",
-	)
+	}, extraArgs...)
+	cmd := exec.Command(server, args...) // #nosec G204 -- server is a binary path built by the test harness, not user input
 	cmd.Env = stripEnv(os.Environ(), "NEO4J_URI", "NEO4J_USERNAME", "NEO4J_PASSWORD", "NEO4J_DATABASE")
 
 	require.NoError(t, cmd.Start(), "failed to start HTTP server")
@@ -107,7 +109,7 @@ func waitForHealthz(t *testing.T, url string) {
 }
 
 // newHTTPClient builds an MCP streamable-HTTP client forwarding the provided headers.
-func newHTTPClient(t *testing.T, mcpURL string, headers map[string]string) *client.Client {
+func newHTTPClient(t *testing.T, mcpURL string, headers map[string]string, opts ...client.ClientOption) *client.Client {
 	t.Helper()
 
 	httpTransport, err := transport.NewStreamableHTTP(mcpURL,
@@ -116,5 +118,5 @@ func newHTTPClient(t *testing.T, mcpURL string, headers map[string]string) *clie
 	)
 	require.NoError(t, err, "failed to build streamable HTTP transport")
 
-	return client.NewClient(httpTransport)
+	return client.NewClient(httpTransport, opts...)
 }

--- a/test/e2e/http_server_per_request_tools_execution_guard_test.go
+++ b/test/e2e/http_server_per_request_tools_execution_guard_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/neo4j/mcp/internal/server"
 	"github.com/neo4j/mcp/test/e2e/helpers"
 
 	"github.com/stretchr/testify/require"
@@ -37,41 +38,41 @@ func TestHTTPPerRequestToolsExecutionGuard(t *testing.T) {
 		},
 		{
 			name:         "When X-Neo4j-MCP-ReadOnly is false, the tool call should succeed",
-			extraHeaders: map[string]string{"X-Neo4j-MCP-ReadOnly": "false"},
+			extraHeaders: map[string]string{mcpserver.ReadOnlyHeader: "false"},
 			toolName:     "write-cypher",
 		},
 		{
 			name:         "When X-Neo4j-MCP-Tools contains the tool being called, the tool call should succeed",
-			extraHeaders: map[string]string{"X-Neo4j-MCP-Tools": "read-cypher, write-cypher"},
+			extraHeaders: map[string]string{mcpserver.ToolsHeader: "read-cypher, write-cypher"},
 			toolName:     "write-cypher",
 		},
 		{
 			name:         "When X-Neo4j-MCP-ReadOnly is true and the tool is read-only, the tool call should succeed",
-			extraHeaders: map[string]string{"X-Neo4j-MCP-ReadOnly": "true"},
+			extraHeaders: map[string]string{mcpserver.ReadOnlyHeader: "true"},
 			toolName:     "get-schema",
 		},
 		{
 			name:         "When X-Neo4j-MCP-ReadOnly is true, a write tool call should be blocked",
-			extraHeaders: map[string]string{"X-Neo4j-MCP-ReadOnly": "true"},
+			extraHeaders: map[string]string{mcpserver.ReadOnlyHeader: "true"},
 			toolName:     "write-cypher",
 			wantErr:      readOnlyError,
 		},
 		{
 			name:         "When X-Neo4j-MCP-ReadOnly is true and the tool is not in X-Neo4j-MCP-Tools, the read-only error should take precedence",
-			extraHeaders: map[string]string{"X-Neo4j-MCP-ReadOnly": "true", "X-Neo4j-MCP-Tools": "get-schema"},
+			extraHeaders: map[string]string{mcpserver.ReadOnlyHeader: "true", mcpserver.ToolsHeader: "get-schema"},
 			toolName:     "write-cypher",
 			wantErr:      readOnlyError,
 		},
 		{
 			name:         "When X-Neo4j-MCP-Tools is set and the tool is not in the list, the tool call should be blocked",
-			extraHeaders: map[string]string{"X-Neo4j-MCP-Tools": "get-schema, write-cypher"},
+			extraHeaders: map[string]string{mcpserver.ToolsHeader: "get-schema, write-cypher"},
 			toolName:     "read-cypher",
 			wantErr:      toolError,
 		},
 		{
 			name: "When X-Neo4j-MCP-ReadOnly is true and the tool is a read tool not present in X-Neo4j-MCP-Tools, the tool call should be blocked",
-			extraHeaders: map[string]string{"X-Neo4j-MCP-ReadOnly": "true",
-				"X-Neo4j-MCP-Tools": "get-schema, write-cypher"},
+			extraHeaders: map[string]string{mcpserver.ReadOnlyHeader: "true",
+				mcpserver.ToolsHeader: "get-schema, write-cypher"},
 			toolName: "read-cypher",
 			wantErr:  toolError,
 		},
@@ -87,8 +88,8 @@ func TestHTTPPerRequestToolsExecutionGuard(t *testing.T) {
 			defer cancel()
 
 			headers := map[string]string{
-				"Authorization":   "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
-				"X-Neo4j-MCP-URI": cfg.URI,
+				"Authorization":     "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
+				mcpserver.URIHeader: cfg.URI,
 			}
 			for k, v := range tc.extraHeaders {
 				headers[k] = v
@@ -158,8 +159,8 @@ func TestHTTPPerRequestToolsExecutionGuardInvalidTool(t *testing.T) {
 			defer cancel()
 
 			headers := map[string]string{
-				"Authorization":   "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
-				"X-Neo4j-MCP-URI": cfg.URI,
+				"Authorization":     "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
+				mcpserver.URIHeader: cfg.URI,
 			}
 
 			httpClient := newHTTPClient(t, baseURL+"/db/neo4j/mcp", headers)

--- a/test/e2e/http_server_per_request_tools_filter_test.go
+++ b/test/e2e/http_server_per_request_tools_filter_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/neo4j/mcp/internal/server"
 	"github.com/neo4j/mcp/test/e2e/helpers"
 
 	"github.com/stretchr/testify/require"
@@ -34,59 +35,59 @@ func TestHTTPPerRequestToolsFilter(t *testing.T) {
 		},
 		{
 			name:          "Only read-only tools when X-Neo4j-MCP-ReadOnly is true",
-			extraHeaders:  map[string]string{"X-Neo4j-MCP-ReadOnly": "true"},
+			extraHeaders:  map[string]string{mcpserver.ReadOnlyHeader: "true"},
 			wantToolNames: []string{"read-cypher", "get-schema", "list-gds-procedures"},
 		},
 		{
 			name:          "All tools when X-Neo4j-MCP-ReadOnly is false",
-			extraHeaders:  map[string]string{"X-Neo4j-MCP-ReadOnly": "false"},
+			extraHeaders:  map[string]string{mcpserver.ReadOnlyHeader: "false"},
 			wantToolNames: []string{"read-cypher", "write-cypher", "get-schema", "list-gds-procedures"},
 		},
 		{
 			name:          "All tools when X-Neo4j-MCP-ReadOnly is False (mixed case)",
-			extraHeaders:  map[string]string{"X-Neo4j-MCP-ReadOnly": "False"},
+			extraHeaders:  map[string]string{mcpserver.ReadOnlyHeader: "False"},
 			wantToolNames: []string{"read-cypher", "write-cypher", "get-schema", "list-gds-procedures"},
 		},
 		{
 			name:         "Error when X-Neo4j-MCP-ReadOnly contains an invalid value",
-			extraHeaders: map[string]string{"X-Neo4j-MCP-ReadOnly": "invalid"},
+			extraHeaders: map[string]string{mcpserver.ReadOnlyHeader: "invalid"},
 			wantErr:      true,
 		},
 		{
 			name:          "Single tool filter via X-Neo4j-MCP-Tools",
-			extraHeaders:  map[string]string{"X-Neo4j-MCP-Tools": "read-cypher"},
+			extraHeaders:  map[string]string{mcpserver.ToolsHeader: "read-cypher"},
 			wantToolNames: []string{"read-cypher"},
 		},
 		{
 			name:          "Comma-separated tools via X-Neo4j-MCP-Tools",
-			extraHeaders:  map[string]string{"X-Neo4j-MCP-Tools": "read-cypher, write-cypher"},
+			extraHeaders:  map[string]string{mcpserver.ToolsHeader: "read-cypher, write-cypher"},
 			wantToolNames: []string{"read-cypher", "write-cypher"},
 		},
 		{
 			name:          "All tools when all available tools are listed in X-Neo4j-MCP-Tools",
-			extraHeaders:  map[string]string{"X-Neo4j-MCP-Tools": "read-cypher, write-cypher, get-schema, list-gds-procedures"},
+			extraHeaders:  map[string]string{mcpserver.ToolsHeader: "read-cypher, write-cypher, get-schema, list-gds-procedures"},
 			wantToolNames: []string{"read-cypher", "write-cypher", "get-schema", "list-gds-procedures"},
 		},
 		{
 			name:         "Error when X-Neo4j-MCP-Tools contains an invalid tool name",
-			extraHeaders: map[string]string{"X-Neo4j-MCP-Tools": "batman-tool"},
+			extraHeaders: map[string]string{mcpserver.ToolsHeader: "batman-tool"},
 			wantErr:      true,
 		},
 		{
 			name:         "Error when X-Neo4j-MCP-Tools contains a mixed valid tool names",
-			extraHeaders: map[string]string{"X-Neo4j-MCP-Tools": "read-cypher, batman-tool"},
+			extraHeaders: map[string]string{mcpserver.ToolsHeader: "read-cypher, batman-tool"},
 			wantErr:      true,
 		},
 		{
 			name:         "Error when X-Neo4j-MCP-Tools contains and \"\" string",
-			extraHeaders: map[string]string{"X-Neo4j-MCP-Tools": ""},
+			extraHeaders: map[string]string{mcpserver.ToolsHeader: ""},
 			wantErr:      true,
 		},
 		{
 			name: "X-Neo4j-MCP-Tools and X-Neo4j-MCP-ReadOnly applied as intersection",
 			extraHeaders: map[string]string{
-				"X-Neo4j-MCP-Tools":   "read-cypher, write-cypher",
-				"X-Neo4j-MCP-ReadOnly": "true",
+				mcpserver.ToolsHeader:    "read-cypher, write-cypher",
+				mcpserver.ReadOnlyHeader: "true",
 			},
 			// write-cypher is not read-only, so it is excluded despite being in the tools list
 			wantToolNames: []string{"read-cypher"},
@@ -102,8 +103,8 @@ func TestHTTPPerRequestToolsFilter(t *testing.T) {
 			defer cancel()
 
 			headers := map[string]string{
-				"Authorization":   "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
-				"X-Neo4j-MCP-URI": cfg.URI,
+				"Authorization":     "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
+				mcpserver.URIHeader: cfg.URI,
 			}
 			for k, v := range tc.extraHeaders {
 				headers[k] = v

--- a/test/e2e/http_server_request_timeout_test.go
+++ b/test/e2e/http_server_request_timeout_test.go
@@ -58,8 +58,8 @@ func TestHTTPRequestTimeoutHeaderValidation(t *testing.T) {
 			cfg := dbs.GetDriverConf()
 
 			headers := map[string]string{
-				"Authorization":                "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
-				"X-Neo4j-MCP-URI":              cfg.URI,
+				"Authorization":               "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
+				"X-Neo4j-MCP-URI":             cfg.URI,
 				"X-Neo4j-MCP-Request-Timeout": tc.timeout,
 			}
 
@@ -165,8 +165,8 @@ func TestHTTPRequestTimeoutToolCall(t *testing.T) {
 			cfg := dbs.GetDriverConf()
 
 			headers := map[string]string{
-				"Authorization":                "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
-				"X-Neo4j-MCP-URI":              cfg.URI,
+				"Authorization":               "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
+				"X-Neo4j-MCP-URI":             cfg.URI,
 				"X-Neo4j-MCP-Request-Timeout": tc.timeout,
 			}
 

--- a/test/e2e/http_server_request_timeout_test.go
+++ b/test/e2e/http_server_request_timeout_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/neo4j/mcp/internal/server"
 	"github.com/neo4j/mcp/test/e2e/helpers"
 
 	"github.com/stretchr/testify/require"
@@ -58,9 +59,9 @@ func TestHTTPRequestTimeoutHeaderValidation(t *testing.T) {
 			cfg := dbs.GetDriverConf()
 
 			headers := map[string]string{
-				"Authorization":               "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
-				"X-Neo4j-MCP-URI":             cfg.URI,
-				"X-Neo4j-MCP-Request-Timeout": tc.timeout,
+				"Authorization":         "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
+				mcpserver.URIHeader:     cfg.URI,
+				mcpserver.TimeoutHeader: tc.timeout,
 			}
 
 			httpClient := newHTTPClient(t, baseURL+"/db/neo4j/mcp", headers, client.WithSession())
@@ -107,11 +108,11 @@ func TestHTTPRequestTimeoutInitialize(t *testing.T) {
 			cfg := dbs.GetDriverConf()
 
 			headers := map[string]string{
-				"Authorization":   "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
-				"X-Neo4j-MCP-URI": cfg.URI,
+				"Authorization":     "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
+				mcpserver.URIHeader: cfg.URI,
 			}
 			if tc.timeout != "" {
-				headers["X-Neo4j-MCP-Request-Timeout"] = tc.timeout
+				headers[mcpserver.TimeoutHeader] = tc.timeout
 			}
 
 			httpClient := newHTTPClient(t, baseURL+"/db/neo4j/mcp", headers)
@@ -165,9 +166,9 @@ func TestHTTPRequestTimeoutToolCall(t *testing.T) {
 			cfg := dbs.GetDriverConf()
 
 			headers := map[string]string{
-				"Authorization":               "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
-				"X-Neo4j-MCP-URI":             cfg.URI,
-				"X-Neo4j-MCP-Request-Timeout": tc.timeout,
+				"Authorization":         "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
+				mcpserver.URIHeader:     cfg.URI,
+				mcpserver.TimeoutHeader: tc.timeout,
 			}
 
 			httpClient := newHTTPClient(t, baseURL+"/db/neo4j/mcp", headers)

--- a/test/e2e/http_server_request_timeout_test.go
+++ b/test/e2e/http_server_request_timeout_test.go
@@ -1,0 +1,207 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/neo4j/mcp/test/e2e/helpers"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestHTTPRequestTimeoutHeaderValidation validate the timeout header validation.
+func TestHTTPRequestTimeoutHeaderValidation(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startHTTPModeServer(t, "--neo4j-request-timeout", "5s")
+
+	tests := []struct {
+		name     string
+		timeout  string
+		wantBody string
+	}{
+		{
+			name:     "When X-Neo4j-MCP-Request-Timeout exceeds the server maximum, the request should be rejected",
+			timeout:  "10s",
+			wantBody: "exceeds server maximum",
+		},
+		{
+			name:     "When X-Neo4j-MCP-Request-Timeout is not a valid duration, the request should be rejected",
+			timeout:  "not-a-duration",
+			wantBody: "must be a valid duration",
+		},
+		{
+			name:     "When X-Neo4j-MCP-Request-Timeout is not positive, the request should be rejected",
+			timeout:  "0s",
+			wantBody: "must be a positive duration",
+		},
+		{
+			name:     "When X-Neo4j-MCP-Request-Timeout is negative, the request should be rejected",
+			timeout:  "-1s",
+			wantBody: "must be a positive duration",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := dbs.GetDriverConf()
+
+			headers := map[string]string{
+				"Authorization":                "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
+				"X-Neo4j-MCP-URI":              cfg.URI,
+				"X-Neo4j-MCP-Request-Timeout": tc.timeout,
+			}
+
+			httpClient := newHTTPClient(t, baseURL+"/db/neo4j/mcp", headers, client.WithSession())
+			defer httpClient.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			err := httpClient.Ping(ctx)
+			require.ErrorContains(t, err, "request failed with status 400")
+			require.ErrorContains(t, err, tc.wantBody)
+		})
+	}
+}
+
+// TestHTTPRequestTimeoutInitialize verifies that an expired request timeout is
+// surfaced as a clear error during the non tool call such initialize
+func TestHTTPRequestTimeoutInitialize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		serverArgs []string
+		timeout    string
+		wantErr    string
+	}{
+		{
+			name:    "When the header timeout expires, initialize should fail with the timeout error",
+			timeout: "1ms",
+			wantErr: "request timed out after 1ms",
+		},
+		{
+			name:       "When the server maximum timeout expires, initialize should fail with the timeout error",
+			serverArgs: []string{"--neo4j-request-timeout", "1ms"},
+			wantErr:    "request timed out after 1ms",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			baseURL := startHTTPModeServer(t, tc.serverArgs...)
+			cfg := dbs.GetDriverConf()
+
+			headers := map[string]string{
+				"Authorization":   "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
+				"X-Neo4j-MCP-URI": cfg.URI,
+			}
+			if tc.timeout != "" {
+				headers["X-Neo4j-MCP-Request-Timeout"] = tc.timeout
+			}
+
+			httpClient := newHTTPClient(t, baseURL+"/db/neo4j/mcp", headers)
+			defer httpClient.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			require.NoError(t, httpClient.Start(ctx), "http client failed to start")
+
+			_, err := httpClient.Initialize(ctx, helpers.BuildInitializeRequest())
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+// TestHTTPRequestTimeoutToolCall verifies that a tool call exceeding the request
+// timeout budget is cancelled and reported as a tool error, while a call within
+// budget succeeds.
+func TestHTTPRequestTimeoutToolCall(t *testing.T) {
+	t.Parallel()
+
+	baseURL := startHTTPModeServer(t)
+
+	tests := []struct {
+		name      string
+		timeout   string
+		query     string
+		wantError bool
+		wantMsg   string
+	}{
+		{
+			name:      "When the tool call exceeds the request timeout, a timeout tool error should be returned",
+			timeout:   "2s",
+			query:     "CALL apoc.util.sleep(5000) RETURN 1 AS n",
+			wantError: true,
+			wantMsg:   "request timed out after 2s",
+		},
+		{
+			name:      "When the tool call completes within the request timeout, it should succeed",
+			timeout:   "5s",
+			query:     "RETURN 1 AS n",
+			wantError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := dbs.GetDriverConf()
+
+			headers := map[string]string{
+				"Authorization":                "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
+				"X-Neo4j-MCP-URI":              cfg.URI,
+				"X-Neo4j-MCP-Request-Timeout": tc.timeout,
+			}
+
+			httpClient := newHTTPClient(t, baseURL+"/db/neo4j/mcp", headers)
+			defer httpClient.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			require.NoError(t, httpClient.Start(ctx), "http client failed to start")
+
+			_, err := httpClient.Initialize(ctx, helpers.BuildInitializeRequest())
+			require.NoError(t, err, "expected initialize to succeed within the %s budget", tc.timeout)
+
+			callToolResponse, err := httpClient.CallTool(ctx, mcp.CallToolRequest{
+				Params: mcp.CallToolParams{
+					Name: "read-cypher",
+					Arguments: map[string]any{
+						"query": tc.query,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			if tc.wantError {
+				require.True(t, callToolResponse.IsError, "expected a tool error, got: %+v", callToolResponse)
+
+				textContent, ok := callToolResponse.Content[0].(mcp.TextContent)
+				require.True(t, ok)
+				require.Contains(t, textContent.Text, tc.wantMsg)
+				return
+			}
+
+			require.False(t, callToolResponse.IsError,
+				"expected tool call to succeed, got: %+v", callToolResponse)
+		})
+	}
+}

--- a/test/e2e/multi_tenant_initialize_test.go
+++ b/test/e2e/multi_tenant_initialize_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	mcpserver "github.com/neo4j/mcp/internal/server"
 	"github.com/neo4j/mcp/test/e2e/helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,8 +47,8 @@ func TestMultiTenantHTTPInitializeIsolation(t *testing.T) {
 	// because Neo4j rejects the password. The initialize call must propagate
 	// that failure back to the client.
 	wrongClient := newHTTPClient(t, mcpURL, map[string]string{
-		"Authorization":   "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":definitely-not-the-password")),
-		"X-Neo4j-MCP-URI": cfg.URI,
+		"Authorization":     "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":definitely-not-the-password")),
+		mcpserver.URIHeader: cfg.URI,
 	})
 	defer wrongClient.Close()
 
@@ -59,8 +60,8 @@ func TestMultiTenantHTTPInitializeIsolation(t *testing.T) {
 	// isolates per-request state, this initialize must succeed even though the
 	// previous one (from a different tenant) failed.
 	rightClient := newHTTPClient(t, mcpURL, map[string]string{
-		"Authorization":   "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
-		"X-Neo4j-MCP-URI": cfg.URI,
+		"Authorization":     "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.Username+":"+cfg.Password)),
+		mcpserver.URIHeader: cfg.URI,
 	})
 	defer rightClient.Close()
 

--- a/test/e2e/stdio_server_request_timeout_test.go
+++ b/test/e2e/stdio_server_request_timeout_test.go
@@ -24,9 +24,9 @@ func TestStdioRequestTimeoutInitialize(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		timeout  string
-		wantErr  string
+		name    string
+		timeout string
+		wantErr string
 	}{
 		{
 			name:    "When the server request timeout expires, initialize should fail with the timeout error",

--- a/test/e2e/stdio_server_request_timeout_test.go
+++ b/test/e2e/stdio_server_request_timeout_test.go
@@ -1,0 +1,142 @@
+// Copyright (c) "Neo4j"
+// Neo4j Sweden AB [http://neo4j.com]
+
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/neo4j/mcp/test/e2e/helpers"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStdioRequestTimeoutInitialize verifies that an expired server request
+// timeout is surfaced as a clear error during initialize. STDIO has no per-request
+// timeout header, so only the server maximum (--neo4j-request-timeout) applies.
+func TestStdioRequestTimeoutInitialize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		timeout  string
+		wantErr  string
+	}{
+		{
+			name:    "When the server request timeout expires, initialize should fail with the timeout error",
+			timeout: "1ms",
+			wantErr: "request timed out after 1ms",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := dbs.GetDriverConf()
+
+			args := []string{
+				"--neo4j-uri", cfg.URI,
+				"--neo4j-username", cfg.Username,
+				"--neo4j-password", cfg.Password,
+				"--neo4j-database", cfg.Database,
+				"--neo4j-telemetry", "false",
+				"--neo4j-request-timeout", tc.timeout,
+			}
+
+			mcpClient, err := client.NewStdioMCPClient(server, []string{}, args...)
+			require.NoError(t, err, "failed to create MCP client")
+			defer mcpClient.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			_, err = mcpClient.Initialize(ctx, helpers.BuildInitializeRequest())
+			require.ErrorContains(t, err, tc.wantErr)
+		})
+	}
+}
+
+// TestStdioRequestTimeoutToolCall verifies that a tool call exceeding the server
+// request timeout is cancelled and reported as a tool error, while a call within
+// budget succeeds.
+func TestStdioRequestTimeoutToolCall(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		timeout   string
+		query     string
+		wantError bool
+		wantMsg   string
+	}{
+		{
+			name:      "When the tool call exceeds the request timeout, a timeout tool error should be returned",
+			timeout:   "2s",
+			query:     "CALL apoc.util.sleep(5000) RETURN 1 AS n",
+			wantError: true,
+			wantMsg:   "request timed out after 2s",
+		},
+		{
+			name:      "When the tool call completes within the request timeout, it should succeed",
+			timeout:   "5s",
+			query:     "RETURN 1 AS n",
+			wantError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := dbs.GetDriverConf()
+
+			args := []string{
+				"--neo4j-uri", cfg.URI,
+				"--neo4j-username", cfg.Username,
+				"--neo4j-password", cfg.Password,
+				"--neo4j-database", cfg.Database,
+				"--neo4j-telemetry", "false",
+				"--neo4j-request-timeout", tc.timeout,
+			}
+
+			mcpClient, err := client.NewStdioMCPClient(server, []string{}, args...)
+			require.NoError(t, err, "failed to create MCP client")
+			defer mcpClient.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			_, err = mcpClient.Initialize(ctx, helpers.BuildInitializeRequest())
+			require.NoError(t, err, "expected initialize to succeed within the %s budget", tc.timeout)
+
+			callToolResponse, err := mcpClient.CallTool(ctx, mcp.CallToolRequest{
+				Params: mcp.CallToolParams{
+					Name: "read-cypher",
+					Arguments: map[string]any{
+						"query": tc.query,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			if tc.wantError {
+				require.True(t, callToolResponse.IsError, "expected a tool error, got: %+v", callToolResponse)
+
+				textContent, ok := callToolResponse.Content[0].(mcp.TextContent)
+				require.True(t, ok)
+				require.Contains(t, textContent.Text, tc.wantMsg)
+				return
+			}
+
+			require.False(t, callToolResponse.IsError,
+				"expected tool call to succeed, got: %+v", callToolResponse)
+		})
+	}
+}

--- a/test/integration/http_methods_test.go
+++ b/test/integration/http_methods_test.go
@@ -135,7 +135,7 @@ func TestHTTPMethodRestrictions(t *testing.T) {
 			setupReq: func(req *http.Request) {
 				req.SetBasicAuth(testCFG.Username, testCFG.Password)
 				req.Header.Set("Content-Type", "application/json")
-				req.Header.Set("X-Neo4j-MCP-URI", testCFG.URI)
+				req.Header.Set(server.URIHeader, testCFG.URI)
 			},
 			wantStatus: http.StatusOK,
 			assertErr:  noErr,
@@ -244,7 +244,7 @@ func TestHTTPMode_URIHeader(t *testing.T) {
 			setupReq: func(req *http.Request) {
 				req.SetBasicAuth(testCFG.Username, testCFG.Password)
 				req.Header.Set("Content-Type", "application/json")
-				req.Header.Set("X-Neo4j-MCP-URI", testCFG.URI)
+				req.Header.Set(server.URIHeader, testCFG.URI)
 			},
 			wantStatus: http.StatusOK,
 		},
@@ -261,7 +261,7 @@ func TestHTTPMode_URIHeader(t *testing.T) {
 			setupReq: func(req *http.Request) {
 				req.SetBasicAuth(testCFG.Username, testCFG.Password)
 				req.Header.Set("Content-Type", "application/json")
-				req.Header.Set("X-Neo4j-MCP-URI", "http://localhost:7687")
+				req.Header.Set(server.URIHeader, "http://localhost:7687")
 			},
 			wantStatus: http.StatusBadRequest,
 		},


### PR DESCRIPTION
Bounds MCP requests with a timeout: 3m default, 30m maximum, set via
`NEO4J_MCP_REQUEST_TIMEOUT` or `--neo4j-request-timeout`. HTTP callers can lower it
per-request with `X-Neo4j-MCP-Request-Timeout`; larger or malformed values return 400.
Tool calls and `initialize` that run past the limit return
`request timed out after <duration>`.
Worth a close look:
- HTTP `WriteTimeout` and graceful shutdown now derive from the request timeout, so
  default shutdown goes from 65s to 3m10s.
- The deadline covers tool calls and `initialize` only, not `tools/list` or `ping`.

Apart from that the HTTP header key have a single definition space and are reused across the codebase.