### PR TITLE
Restore log configuration validation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,8 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+
+	"github.com/neo4j/mcp/internal/logger"
 )
 
 type TransportMode string
@@ -128,6 +130,21 @@ type CLIOverrides struct {
 func LoadConfig(cliOverrides *CLIOverrides) (*Config, error) {
 	warnOnDeprecatedUsage()
 
+	logLevel := GetEnvWithAliasesDefault("NEO4J_MCP_LOG_LEVEL", "info", "NEO4J_LOG_LEVEL")
+	logFormat := GetEnvWithAliasesDefault("NEO4J_MCP_LOG_FORMAT", "text", "NEO4J_LOG_FORMAT")
+
+	// Validate log level and use default if invalid
+	if !slices.Contains(logger.ValidLogLevels, logLevel) {
+		fmt.Fprintf(os.Stderr, "Warning: invalid NEO4J_MCP_LOG_LEVEL '%s', using default 'info'. Valid values: %v\n", logLevel, logger.ValidLogLevels)
+		logLevel = "info"
+	}
+
+	// Validate log format and use default if invalid
+	if !slices.Contains(logger.ValidLogFormats, logFormat) {
+		fmt.Fprintf(os.Stderr, "Warning: invalid NEO4J_MCP_LOG_FORMAT '%s', using default 'text'. Valid values: %v\n", logFormat, logger.ValidLogFormats)
+		logFormat = "text"
+	}
+
 	cfg := &Config{
 		URI:                           GetEnvWithAliases("NEO4J_MCP_URI", "NEO4J_URI"),
 		Username:                      GetEnvWithAliases("NEO4J_MCP_USERNAME", "NEO4J_USERNAME"),
@@ -135,8 +152,8 @@ func LoadConfig(cliOverrides *CLIOverrides) (*Config, error) {
 		Database:                      GetEnvWithAliasesDefault("NEO4J_MCP_DATABASE", "neo4j", "NEO4J_DATABASE"),
 		ReadOnly:                      ParseBool(GetEnvWithAliases("NEO4J_MCP_READ_ONLY", "NEO4J_READ_ONLY"), false),
 		Telemetry:                     ParseBool(GetEnvWithAliases("NEO4J_MCP_TELEMETRY", "NEO4J_TELEMETRY"), true),
-		LogLevel:                      GetEnvWithAliasesDefault("NEO4J_MCP_LOG_LEVEL", "info", "NEO4J_LOG_LEVEL"),
-		LogFormat:                     GetEnvWithAliasesDefault("NEO4J_MCP_LOG_FORMAT", "text", "NEO4J_LOG_FORMAT"),
+		LogLevel:                      logLevel,
+		LogFormat:                     logFormat,
 		SchemaSampleSize:              ParseInt32(GetEnvWithAliases("NEO4J_MCP_SCHEMA_SAMPLE_SIZE", "NEO4J_SCHEMA_SAMPLE_SIZE"), DefaultSchemaSampleSize),
 		TransportMode:                 TransportMode(GetEnvWithAliasesDefault("NEO4J_MCP_TRANSPORT_MODE", string(TransportModeStdio), "NEO4J_TRANSPORT_MODE", "NEO4J_MCP_TRANSPORT")),
 		HTTPPort:                      GetEnv("NEO4J_MCP_HTTP_PORT"), // Default set after TLS determination

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -459,6 +459,36 @@ func TestLoadConfig_CanonicalEnvironmentVariables(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_InvalidLogConfigurationFallsBackToDefaults(t *testing.T) {
+	t.Setenv("NEO4J_MCP_URI", "bolt://localhost:7687")
+	t.Setenv("NEO4J_MCP_USERNAME", "neo4j")
+	t.Setenv("NEO4J_MCP_PASSWORD", "password")
+	t.Setenv("NEO4J_MCP_TRANSPORT_MODE", "stdio")
+	t.Setenv("NEO4J_MCP_LOG_LEVEL", "DEBUG")
+	t.Setenv("NEO4J_MCP_LOG_FORMAT", "JSON")
+
+	var cfg *Config
+	var loadErr error
+	_, stderr := captureOutput(func() {
+		cfg, loadErr = LoadConfig(nil)
+	})
+	if loadErr != nil {
+		t.Fatalf("LoadConfig() unexpected error: %v", loadErr)
+	}
+	if cfg.LogLevel != "info" {
+		t.Errorf("LoadConfig() LogLevel = %q, want default %q", cfg.LogLevel, "info")
+	}
+	if cfg.LogFormat != "text" {
+		t.Errorf("LoadConfig() LogFormat = %q, want default %q", cfg.LogFormat, "text")
+	}
+	if !strings.Contains(stderr, "invalid NEO4J_MCP_LOG_LEVEL 'DEBUG'") {
+		t.Errorf("stderr = %q, want invalid log level warning", stderr)
+	}
+	if !strings.Contains(stderr, "invalid NEO4J_MCP_LOG_FORMAT 'JSON'") {
+		t.Errorf("stderr = %q, want invalid log format warning", stderr)
+	}
+}
+
 func TestLoadConfig_DeprecatedEnvironmentAliasWarningAndPrecedence(t *testing.T) {
 	t.Setenv("NEO4J_MCP_URI", "bolt://canonical-host:7687")
 	t.Setenv("NEO4J_MCP_USERNAME", "canonical-user")


### PR DESCRIPTION
Restores warnings and default fallbacks for invalid log levels and formats after environment alias resolution. Adds regression coverage for case-sensitive validation.
This regression was mistakenly introduced by PR https://github.com/neo4j/mcp/pull/324 at https://github.com/neo4j/mcp/pull/324/changes#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL131-L144