### PR TITLE
Remove deprecated environment variables and CLI flags from 2.x branch

### DIFF
--- a/.changes/unreleased/Major-20260416-111021.yaml
+++ b/.changes/unreleased/Major-20260416-111021.yaml
@@ -2,6 +2,6 @@ kind: Major
 body: |
   HTTP mode: URL path changed from /mcp to /db/{databaseName}/mcp, which allows targeting specific databases in a multi-database Neo4j instance.
   All HTTP mode requests must now include the target database name in the URL path. The previous /mcp endpoint no longer exists.
-  NEO4J_DATABASE / --neo4j-database are rejected in HTTP mode. Setting these in HTTP mode now causes a startup error.
-  STDIO mode: NEO4J_DATABASE no longer defaults to "neo4j". This configuration option now needs to be set explicitly when using STDIO. Set NEO4J_DATABASE=neo4j explicitly to preserve the previous behaviour.
+  NEO4J_MCP_DATABASE / --neo4j-database are rejected in HTTP mode. Setting these in HTTP mode now causes a startup error.
+  STDIO mode: NEO4J_MCP_DATABASE no longer defaults to "neo4j". This configuration option now needs to be set explicitly when using STDIO. Set NEO4J_MCP_DATABASE=neo4j explicitly to preserve the previous behaviour.
 time: 2026-04-16T11:10:21.6361+01:00

--- a/.changes/unreleased/Major-20260416-111021.yaml
+++ b/.changes/unreleased/Major-20260416-111021.yaml
@@ -2,6 +2,6 @@ kind: Major
 body: |
   HTTP mode: URL path changed from /mcp to /db/{databaseName}/mcp, which allows targeting specific databases in a multi-database Neo4j instance.
   All HTTP mode requests must now include the target database name in the URL path. The previous /mcp endpoint no longer exists.
-  NEO4J_MCP_DATABASE / --neo4j-database are rejected in HTTP mode. Setting these in HTTP mode now causes a startup error.
+  NEO4J_MCP_DATABASE / --database are rejected in HTTP mode. Setting these in HTTP mode now causes a startup error.
   STDIO mode: NEO4J_MCP_DATABASE no longer defaults to "neo4j". This configuration option now needs to be set explicitly when using STDIO. Set NEO4J_MCP_DATABASE=neo4j explicitly to preserve the previous behaviour.
 time: 2026-04-16T11:10:21.6361+01:00

--- a/.changes/unreleased/Major-20260506-230902.yaml
+++ b/.changes/unreleased/Major-20260506-230902.yaml
@@ -1,7 +1,7 @@
 kind: Major
 body: |
   HTTP mode now accepts X-Neo4j-MCP-URI header to specify which Neo4j instance to connect to per-request. (#278)
-  NEO4J_URI env var is no longer required in HTTP mode — URI comes from the header instead.
+  NEO4J_MCP_URI env var is no longer required in HTTP mode — URI comes from the header instead.
   Requests without a valid X-Neo4j-MCP-URI get 400 Bad Request.
   X-Neo4j-MCP-URI added to CORS Access-Control-Allow-Headers.
   Bolt URI passwords are now redacted from error messages.

--- a/.changes/unreleased/Major-20260824-174500.yaml
+++ b/.changes/unreleased/Major-20260824-174500.yaml
@@ -1,4 +1,41 @@
 kind: Major
 body: |
-  Removed deprecated environment-variable aliases and --neo4j-* CLI flags; user-facing environment variables now use the NEO4J_MCP_ prefix.
+  Removed deprecated environment-variable aliases and CLI flags. Environment variables are now scoped with the `NEO4J_MCP_` prefix, while CLI flags use concise, unscoped names. 
+  Use the following replacements:
+
+  | Type | Removed | Replacement |
+  | --- | --- | --- |
+  | Environment variable | `NEO4J_URI` | `NEO4J_MCP_URI` |
+  | Environment variable | `NEO4J_USERNAME` | `NEO4J_MCP_USERNAME` |
+  | Environment variable | `NEO4J_PASSWORD` | `NEO4J_MCP_PASSWORD` |
+  | Environment variable | `NEO4J_DATABASE` | `NEO4J_MCP_DATABASE` |
+  | Environment variable | `NEO4J_READ_ONLY` | `NEO4J_MCP_READ_ONLY` |
+  | Environment variable | `NEO4J_TELEMETRY` | `NEO4J_MCP_TELEMETRY` |
+  | Environment variable | `NEO4J_LOG_LEVEL` | `NEO4J_MCP_LOG_LEVEL` |
+  | Environment variable | `NEO4J_LOG_FORMAT` | `NEO4J_MCP_LOG_FORMAT` |
+  | Environment variable | `NEO4J_SCHEMA_SAMPLE_SIZE` | `NEO4J_MCP_SCHEMA_SAMPLE_SIZE` |
+  | Environment variable | `NEO4J_TRANSPORT_MODE` | `NEO4J_MCP_TRANSPORT_MODE` |
+  | Environment variable | `NEO4J_MCP_TRANSPORT` | `NEO4J_MCP_TRANSPORT_MODE` |
+  | Environment variable | `NEO4J_HTTP_AUTH_HEADER_NAME` | `NEO4J_MCP_HTTP_AUTH_HEADER_NAME` |
+  | Environment variable | `NEO4J_HTTP_ALLOW_UNAUTHENTICATED_PING` | `NEO4J_MCP_HTTP_ALLOW_UNAUTHENTICATED_PING` |
+  | Environment variable | `NEO4J_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST` | `NEO4J_MCP_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST` |
+  | CLI flag | `--neo4j-uri` | `--uri` |
+  | CLI flag | `--neo4j-username` | `--username` |
+  | CLI flag | `--neo4j-password` | `--password` |
+  | CLI flag | `--neo4j-database` | `--database` |
+  | CLI flag | `--neo4j-read-only` | `--read-only` |
+  | CLI flag | `--neo4j-tools` | `--tools` |
+  | CLI flag | `--neo4j-telemetry` | `--telemetry` |
+  | CLI flag | `--neo4j-schema-sample-size` | `--schema-sample-size` |
+  | CLI flag | `--neo4j-transport-mode` | `--transport-mode` |
+  | CLI flag | `--neo4j-http-port` | `--http-port` |
+  | CLI flag | `--neo4j-http-host` | `--http-host` |
+  | CLI flag | `--neo4j-http-allowed-origins` | `--http-allowed-origins` |
+  | CLI flag | `--neo4j-http-tls-enabled` | `--http-tls-enabled` |
+  | CLI flag | `--neo4j-http-tls-cert-file` | `--http-tls-cert-file` |
+  | CLI flag | `--neo4j-http-tls-key-file` | `--http-tls-key-file` |
+  | CLI flag | `--neo4j-http-auth-header-name` | `--http-auth-header-name` |
+  | CLI flag | `--neo4j-http-allow-unauthenticated-ping` | `--http-allow-unauthenticated-ping` |
+  | CLI flag | `--neo4j-http-allow-unauthenticated-tools-list` | `--http-allow-unauthenticated-tools-list` |
+  | CLI flag | `--neo4j-request-timeout` | `--request-timeout` |
 time: 2026-08-24T17:45:00+01:00

--- a/.changes/unreleased/Major-20260824-174500.yaml
+++ b/.changes/unreleased/Major-20260824-174500.yaml
@@ -1,0 +1,4 @@
+kind: Major
+body: |
+  Removed deprecated environment-variable aliases and --neo4j-* CLI flags; user-facing environment variables now use the NEO4J_MCP_ prefix.
+time: 2026-08-24T17:45:00+01:00

--- a/.changes/unreleased/Minor-20260528-110236.yaml
+++ b/.changes/unreleased/Minor-20260528-110236.yaml
@@ -1,6 +1,6 @@
 kind: Minor
 body: |
-  The server now supports selective tool filtering through the "NEO4J_MCP_TOOLS" environment variable or the "--neo4j-tools" CLI argument.
+  The server now supports selective tool filtering through the "NEO4J_MCP_TOOLS" environment variable or the "--tools" CLI argument.
   These values are used to filter the tools returned in the "tools/list" MCP response. If not specified, all tools will be enabled.
-  You can pass multiple tools at once as a comma-separated list. Example: "--neo4j-tools 'get-schema,read-cypher'".
+  You can pass multiple tools at once as a comma-separated list. Example: "--tools 'get-schema,read-cypher'".
 time: 2026-05-28T11:02:36.109105+01:00

--- a/.changes/unreleased/Minor-20260730-181827.yaml
+++ b/.changes/unreleased/Minor-20260730-181827.yaml
@@ -1,7 +1,7 @@
 kind: Minor
 body: |
   MCP requests are now bounded by a timeout, 3m by default and 30m at most.
-  - Set the server limit with `NEO4J_MCP_REQUEST_TIMEOUT` or `--neo4j-request-timeout` (e.g. `45s`, `5m`)
+  - Set the server limit with `NEO4J_MCP_REQUEST_TIMEOUT` or `--request-timeout` (e.g. `45s`, `5m`)
   - HTTP mode accepts a per-request `X-Neo4j-MCP-Request-Timeout` header, which can only lower the server limit; larger, non-positive, or malformed values return `400 Bad Request`
   - Tool calls and `initialize` that run past the limit are cancelled and return a `request timed out after <duration>` error
 time: 2026-07-30T18:18:27.279087+01:00

--- a/README.md
+++ b/README.md
@@ -23,18 +23,18 @@ By implementing the Model Context Protocol (MCP), it acts as a bridge between an
 
 v2 makes HTTP mode multi-tenant: the target database and Neo4j URI now come from each request, so one server can serve multiple instances.
 
-**STDIO mode** — `NEO4J_DATABASE` no longer defaults to `"neo4j"` and must be set explicitly. Otherwise the server fails to start with:
+**STDIO mode** — `NEO4J_MCP_DATABASE` no longer defaults to `"neo4j"` and must be set explicitly. Otherwise the server fails to start with:
 
-> `Neo4j database is required for STDIO mode (set NEO4J_DATABASE or use --neo4j-database flag)`
+> `Neo4j database is required for STDIO mode (set NEO4J_MCP_DATABASE or use --database flag)`
 
 **HTTP mode** — server config moves to per-request headers and URL path.
 
 Server environment:
 
 ```diff
-- NEO4J_URI=bolt://host:7687
-- NEO4J_DATABASE=neo4j
-  NEO4J_TRANSPORT_MODE=http
+- NEO4J_MCP_URI=bolt://host:7687
+- NEO4J_MCP_DATABASE=neo4j
+  NEO4J_MCP_TRANSPORT_MODE=http
 ```
 
 Request:
@@ -48,9 +48,9 @@ Request:
 
 ### Breaking changes in HTTP mode to be aware of when migrating:
 
-- If `NEO4J_DATABASE` is still set in HTTP mode, the server refuses to start with `NEO4J_DATABASE … should not be set for HTTP transport mode; database is selected per-request via URL path`.
-- Similarly, setting `NEO4J_USERNAME` or `NEO4J_PASSWORD` in HTTP mode causes startup failure, since credentials must be provided via Basic Auth on each request.
-- `NEO4J_URI` must also be empty at startup in HTTP mode, since the target Neo4j instance is determined per-request via the `X-Neo4j-MCP-URI` header. Setting `NEO4J_URI` in HTTP mode results in startup failure with `Neo4j URI should not be set for HTTP transport mode; URI is provided per-request via X-Neo4j-MCP-URI header`.
+- If `NEO4J_MCP_DATABASE` is still set in HTTP mode, the server refuses to start with `NEO4J_MCP_DATABASE … should not be set for HTTP transport mode; database is selected per-request via URL path`.
+- Similarly, setting `NEO4J_MCP_USERNAME` or `NEO4J_MCP_PASSWORD` in HTTP mode causes startup failure, since credentials must be provided via Basic Auth on each request.
+- `NEO4J_MCP_URI` must also be empty at startup in HTTP mode, since the target Neo4j instance is determined per-request via the `X-Neo4j-MCP-URI` header. Setting `NEO4J_MCP_URI` in HTTP mode results in startup failure with `Neo4j URI should not be set for HTTP transport mode; URI is provided per-request via X-Neo4j-MCP-URI header`.
 
 ## Installation
 

--- a/internal/cli/args.go
+++ b/internal/cli/args.go
@@ -27,7 +27,7 @@ Options:
   --password <PASSWORD>               Database password (overrides NEO4J_MCP_PASSWORD)
   --database <DATABASE>               Database name (overrides NEO4J_MCP_DATABASE)
   --read-only <BOOLEAN>               Enable read-only mode: true or false (overrides NEO4J_MCP_READ_ONLY)
-  --tools <TOOLS>               	  Define tools available by filtering tools returned in tools/list response
+  --tools <TOOLS>                     Define tools available by filtering tools returned in tools/list response
   --telemetry <BOOLEAN>               Enable telemetry: true or false (overrides NEO4J_MCP_TELEMETRY)
   --schema-sample-size <INT>          Number of nodes to sample for schema inference (overrides NEO4J_MCP_SCHEMA_SAMPLE_SIZE)
   --transport-mode <MODE>             MCP transport mode: 'stdio' or 'http' (overrides NEO4J_MCP_TRANSPORT_MODE)
@@ -40,7 +40,7 @@ Options:
   --http-auth-header-name <HEADER>    Name of the HTTP header to read auth credentials from (overrides NEO4J_MCP_HTTP_AUTH_HEADER_NAME)
   --http-allow-unauthenticated-ping <BOOLEAN> Allow unauthenticated ping (overrides NEO4J_MCP_HTTP_ALLOW_UNAUTHENTICATED_PING)
   --http-allow-unauthenticated-tools-list <BOOLEAN> Allow unauthenticated tools/list (overrides NEO4J_MCP_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST)
-  --neo4j-request-timeout <DURATION>  Maximum duration for a single MCP request, up to 30m. Also caps the per-request X-Neo4j-MCP-Request-Timeout header in HTTP mode (overrides environment variable NEO4J_MCP_REQUEST_TIMEOUT)
+  --request-timeout <DURATION>       Maximum duration for a single MCP request, up to 30m. Also caps the per-request X-Neo4j-MCP-Request-Timeout header in HTTP mode (overrides environment variable NEO4J_MCP_REQUEST_TIMEOUT)
 
 Required Environment Variables (STDIO mode):
   NEO4J_MCP_URI       Neo4j database URI
@@ -66,8 +66,6 @@ Optional Environment Variables:
   NEO4J_MCP_HTTP_ALLOW_UNAUTHENTICATED_PING Allow unauthenticated ping health checks (default: false)
   NEO4J_MCP_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST Allow unauthenticated tool listing (default: false)
   NEO4J_MCP_REQUEST_TIMEOUT Maximum duration for a single MCP request (default: 3m, maximum: 30m)
-
-Deprecated environment variables and --neo4j-* flags remain accepted in v1 and emit a warning. They will be removed in v2. The deprecated environment aliases are the previous unscoped names shown in the project changelog.
 
 Examples:
   # Using environment variables
@@ -106,123 +104,77 @@ type Args struct {
 // add new config flags here as needed
 var argsSlice = []string{
 	"--uri",
-	"--neo4j-uri",
 	"--username",
-	"--neo4j-username",
 	"--password",
-	"--neo4j-password",
 	"--database",
-	"--neo4j-database",
 	"--read-only",
-	"--neo4j-read-only",
-	"--neo4j-tools",
+	"--tools",
 	"--telemetry",
-	"--neo4j-telemetry",
 	"--schema-sample-size",
-	"--neo4j-schema-sample-size",
 	"--transport-mode",
-	"--neo4j-transport-mode",
 	"--http-port",
-	"--neo4j-http-port",
 	"--http-host",
-	"--neo4j-http-host",
 	"--http-allowed-origins",
-	"--neo4j-http-allowed-origins",
 	"--http-tls-enabled",
-	"--neo4j-http-tls-enabled",
 	"--http-tls-cert-file",
-	"--neo4j-http-tls-cert-file",
 	"--http-tls-key-file",
-	"--neo4j-http-tls-key-file",
 	"--http-auth-header-name",
-	"--neo4j-http-auth-header-name",
 	"--http-allow-unauthenticated-ping",
-	"--neo4j-http-allow-unauthenticated-ping",
 	"--http-allow-unauthenticated-tools-list",
-	"--neo4j-http-allow-unauthenticated-tools-list",
-	"--neo4j-request-timeout",
+	"--request-timeout",
 }
 
 // ParseConfigFlags parses CLI flags and returns configuration values.
 // It should be called after HandleArgs to ensure help/version flags are processed first.
-const deprecatedFlagMessage = "Warning: deprecated CLI flag %q; use %q instead. Support will be removed in v2.\n"
-
-func mergeFlagValue(canonical, deprecated *string, canonicalName, deprecatedName string) string {
-	if *deprecated != "" {
-		fmt.Fprintf(os.Stderr, deprecatedFlagMessage, deprecatedName, canonicalName)
-	}
-	if *canonical != "" {
-		return *canonical
-	}
-	return *deprecated
-}
-
 func ParseConfigFlags() *Args {
 	uri := flag.String("uri", "", "Neo4j connection URI (overrides NEO4J_MCP_URI env var)")
-	neo4jURI := flag.String("neo4j-uri", "", "Deprecated alias for --uri")
 	username := flag.String("username", "", "Neo4j username (overrides NEO4J_MCP_USERNAME env var)")
-	neo4jUsername := flag.String("neo4j-username", "", "Deprecated alias for --username")
 	password := flag.String("password", "", "Neo4j password (overrides NEO4J_MCP_PASSWORD env var)")
-	neo4jPassword := flag.String("neo4j-password", "", "Deprecated alias for --password")
 	database := flag.String("database", "", "Neo4j database name (overrides NEO4J_MCP_DATABASE env var)")
-	neo4jDatabase := flag.String("neo4j-database", "", "Deprecated alias for --database")
 	readOnly := flag.String("read-only", "", "Enable read-only mode: true or false (overrides NEO4J_MCP_READ_ONLY env var)")
-	neo4jReadOnly := flag.String("neo4j-read-only", "", "Deprecated alias for --read-only")
-	var neo4jTools *string
-	flag.Func("neo4j-tools", "Define tools available by filtering tools returned in tools/list response", func(s string) error {
+	var tools *string
+	flag.Func("tools", "Define tools available by filtering tools returned in tools/list response", func(s string) error {
 		if s == "" {
 			return fmt.Errorf("cannot be empty; omit the flag to use all tools, or provide a comma-separated list of tools")
 		}
-		neo4jTools = &s
+		tools = &s
 		return nil
 	})
 	telemetry := flag.String("telemetry", "", "Enable telemetry: true or false (overrides NEO4J_MCP_TELEMETRY env var)")
-	neo4jTelemetry := flag.String("neo4j-telemetry", "", "Deprecated alias for --telemetry")
 	schemaSampleSize := flag.String("schema-sample-size", "", "Number of nodes to sample for schema inference (overrides NEO4J_MCP_SCHEMA_SAMPLE_SIZE env var)")
-	neo4jSchemaSampleSize := flag.String("neo4j-schema-sample-size", "", "Deprecated alias for --schema-sample-size")
 	transportMode := flag.String("transport-mode", "", "MCP transport mode: stdio or http (overrides NEO4J_MCP_TRANSPORT_MODE env var)")
-	neo4jTransportMode := flag.String("neo4j-transport-mode", "", "Deprecated alias for --transport-mode")
 	httpPort := flag.String("http-port", "", "HTTP server port (overrides NEO4J_MCP_HTTP_PORT env var)")
-	neo4jHTTPPort := flag.String("neo4j-http-port", "", "Deprecated alias for --http-port")
 	httpHost := flag.String("http-host", "", "HTTP server host (overrides NEO4J_MCP_HTTP_HOST env var)")
-	neo4jHTTPHost := flag.String("neo4j-http-host", "", "Deprecated alias for --http-host")
 	httpAllowedOrigins := flag.String("http-allowed-origins", "", "Comma-separated list of allowed CORS origins (overrides NEO4J_MCP_HTTP_ALLOWED_ORIGINS env var)")
-	neo4jHTTPAllowedOrigins := flag.String("neo4j-http-allowed-origins", "", "Deprecated alias for --http-allowed-origins")
 	httpTLSEnabled := flag.String("http-tls-enabled", "", "Enable TLS/HTTPS for HTTP server: true or false (overrides NEO4J_MCP_HTTP_TLS_ENABLED env var)")
-	neo4jHTTPTLSEnabled := flag.String("neo4j-http-tls-enabled", "", "Deprecated alias for --http-tls-enabled")
 	httpTLSCertFile := flag.String("http-tls-cert-file", "", "Path to TLS certificate file (overrides NEO4J_MCP_HTTP_TLS_CERT_FILE env var)")
-	neo4jHTTPTLSCertFile := flag.String("neo4j-http-tls-cert-file", "", "Deprecated alias for --http-tls-cert-file")
 	httpTLSKeyFile := flag.String("http-tls-key-file", "", "Path to TLS private key file (overrides NEO4J_MCP_HTTP_TLS_KEY_FILE env var)")
-	neo4jHTTPTLSKeyFile := flag.String("neo4j-http-tls-key-file", "", "Deprecated alias for --http-tls-key-file")
 	authHeaderName := flag.String("http-auth-header-name", "", "Name of the HTTP header to read auth credentials from (overrides NEO4J_MCP_HTTP_AUTH_HEADER_NAME env var)")
-	neo4jAuthHeaderName := flag.String("neo4j-http-auth-header-name", "", "Deprecated alias for --http-auth-header-name")
 	allowUnauthenticatedPing := flag.String("http-allow-unauthenticated-ping", "", "Allow unauthenticated ping: true or false (overrides NEO4J_MCP_HTTP_ALLOW_UNAUTHENTICATED_PING env var)")
-	neo4jHTTPAllowUnauthenticatedPing := flag.String("neo4j-http-allow-unauthenticated-ping", "", "Deprecated alias for --http-allow-unauthenticated-ping")
 	allowUnauthenticatedToolsList := flag.String("http-allow-unauthenticated-tools-list", "", "Allow unauthenticated tools/list: true or false (overrides NEO4J_MCP_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST env var)")
-	neo4jHTTPAllowUnauthenticatedToolsList := flag.String("neo4j-http-allow-unauthenticated-tools-list", "", "Deprecated alias for --http-allow-unauthenticated-tools-list")
-	neo4jRequestTimeout := flag.String("neo4j-request-timeout", "", "Maximum duration for a single MCP request, up to 30m (overrides NEO4J_MCP_REQUEST_TIMEOUT env var)")
+	requestTimeout := flag.String("request-timeout", "", "Maximum duration for a single MCP request, up to 30m (overrides NEO4J_MCP_REQUEST_TIMEOUT env var)")
 	flag.Parse()
 
 	return &Args{
-		URI:                               mergeFlagValue(uri, neo4jURI, "--uri", "--neo4j-uri"),
-		Username:                          mergeFlagValue(username, neo4jUsername, "--username", "--neo4j-username"),
-		Password:                          mergeFlagValue(password, neo4jPassword, "--password", "--neo4j-password"),
-		Database:                          mergeFlagValue(database, neo4jDatabase, "--database", "--neo4j-database"),
-		ReadOnly:                          mergeFlagValue(readOnly, neo4jReadOnly, "--read-only", "--neo4j-read-only"),
-		Tools:                             neo4jTools,
-		Telemetry:                         mergeFlagValue(telemetry, neo4jTelemetry, "--telemetry", "--neo4j-telemetry"),
-		SchemaSampleSize:                  mergeFlagValue(schemaSampleSize, neo4jSchemaSampleSize, "--schema-sample-size", "--neo4j-schema-sample-size"),
-		TransportMode:                     mergeFlagValue(transportMode, neo4jTransportMode, "--transport-mode", "--neo4j-transport-mode"),
-		HTTPPort:                          mergeFlagValue(httpPort, neo4jHTTPPort, "--http-port", "--neo4j-http-port"),
-		HTTPHost:                          mergeFlagValue(httpHost, neo4jHTTPHost, "--http-host", "--neo4j-http-host"),
-		HTTPAllowedOrigins:                mergeFlagValue(httpAllowedOrigins, neo4jHTTPAllowedOrigins, "--http-allowed-origins", "--neo4j-http-allowed-origins"),
-		HTTPTLSEnabled:                    mergeFlagValue(httpTLSEnabled, neo4jHTTPTLSEnabled, "--http-tls-enabled", "--neo4j-http-tls-enabled"),
-		HTTPTLSCertFile:                   mergeFlagValue(httpTLSCertFile, neo4jHTTPTLSCertFile, "--http-tls-cert-file", "--neo4j-http-tls-cert-file"),
-		HTTPTLSKeyFile:                    mergeFlagValue(httpTLSKeyFile, neo4jHTTPTLSKeyFile, "--http-tls-key-file", "--neo4j-http-tls-key-file"),
-		HTTPAllowUnauthenticatedPing:      mergeFlagValue(allowUnauthenticatedPing, neo4jHTTPAllowUnauthenticatedPing, "--http-allow-unauthenticated-ping", "--neo4j-http-allow-unauthenticated-ping"),
-		HTTPAllowUnauthenticatedToolsList: mergeFlagValue(allowUnauthenticatedToolsList, neo4jHTTPAllowUnauthenticatedToolsList, "--http-allow-unauthenticated-tools-list", "--neo4j-http-allow-unauthenticated-tools-list"),
-		AuthHeaderName:                    mergeFlagValue(authHeaderName, neo4jAuthHeaderName, "--http-auth-header-name", "--neo4j-http-auth-header-name"),
-		RequestTimeout:                    *neo4jRequestTimeout,
+		URI:                               *uri,
+		Username:                          *username,
+		Password:                          *password,
+		Database:                          *database,
+		ReadOnly:                          *readOnly,
+		Tools:                             tools,
+		Telemetry:                         *telemetry,
+		SchemaSampleSize:                  *schemaSampleSize,
+		TransportMode:                     *transportMode,
+		HTTPPort:                          *httpPort,
+		HTTPHost:                          *httpHost,
+		HTTPAllowedOrigins:                *httpAllowedOrigins,
+		HTTPTLSEnabled:                    *httpTLSEnabled,
+		HTTPTLSCertFile:                   *httpTLSCertFile,
+		HTTPTLSKeyFile:                    *httpTLSKeyFile,
+		HTTPAllowUnauthenticatedPing:      *allowUnauthenticatedPing,
+		HTTPAllowUnauthenticatedToolsList: *allowUnauthenticatedToolsList,
+		AuthHeaderName:                    *authHeaderName,
+		RequestTimeout:                    *requestTimeout,
 	}
 }
 

--- a/internal/cli/args_test.go
+++ b/internal/cli/args_test.go
@@ -4,7 +4,6 @@
 package cli
 
 import (
-	"flag"
 	"io"
 	"os"
 	"strings"
@@ -54,252 +53,7 @@ func (m *exitMock) Exit(code int) {
 	panic(m)
 }
 
-func TestHandleArgs_DeprecatedFlag(t *testing.T) {
-	tests := []struct {
-		name             string
-		args             []string
-		version          string
-		expectedExitCode int    // -1 means no exit, 0 or 1 for exit codes
-		expectedOutput   string // substring to find in stdout or stderr
-		expectedStderr   string // substring to find in stderr (if non-empty, output is checked in stderr instead of stdout)
-	}{
-		{
-			name:             "neo4j-uri configuration flag",
-			args:             []string{testProgramName, "--neo4j-uri", "bolt://localhost:7687"},
-			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, flag is allowed
-		},
-		{
-			name:             "multiple configuration flags",
-			args:             []string{testProgramName, "--neo4j-uri", "bolt://localhost:7687", "--neo4j-username", "user"},
-			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, flags are allowed
-		},
-		{
-			name:             "configuration flag missing value - at end",
-			args:             []string{testProgramName, "--neo4j-uri"},
-			version:          testVersion,
-			expectedExitCode: 1,
-			expectedStderr:   "--neo4j-uri requires a value",
-		},
-		{
-			name:             "configuration flag missing value - followed by another flag",
-			args:             []string{testProgramName, "--neo4j-uri", "--neo4j-username", "user"},
-			version:          testVersion,
-			expectedExitCode: 1,
-			expectedStderr:   "--neo4j-uri requires a value (got flag --neo4j-username instead)",
-		},
-		{
-			name:             "neo4j-password missing value",
-			args:             []string{testProgramName, "--neo4j-password"},
-			version:          testVersion,
-			expectedExitCode: 1,
-			expectedStderr:   "--neo4j-password requires a value",
-		},
-		{
-			name:             "neo4j-database missing value - followed by another flag",
-			args:             []string{testProgramName, "--neo4j-database", "--neo4j-uri", "bolt://localhost"},
-			version:          testVersion,
-			expectedExitCode: 1,
-			expectedStderr:   "--neo4j-database requires a value (got flag --neo4j-uri instead)",
-		},
-		{
-			name:             "configuration flags with valid values",
-			args:             []string{testProgramName, "--neo4j-uri", "bolt://localhost:7687", "--neo4j-username", "neo4j", "--neo4j-password", "password", "--neo4j-database", "neo4j"},
-			version:          testVersion,
-			expectedExitCode: -1, // Should not exit
-		},
-		{
-			name:             "schema sample size flag with valid value",
-			args:             []string{testProgramName, "--neo4j-schema-sample-size", "500"},
-			version:          testVersion,
-			expectedExitCode: -1, // Should not exit
-		},
-		{
-			name:             "schema sample size flag missing value",
-			args:             []string{testProgramName, "--neo4j-schema-sample-size"},
-			version:          testVersion,
-			expectedExitCode: 1,
-			expectedStderr:   "--neo4j-schema-sample-size requires a value",
-		},
-		{
-			name:             "transport mode flag valid value",
-			args:             []string{testProgramName, "--neo4j-transport-mode", "http"},
-			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, flag is allowed
-		},
-		{
-			name:             "transport mode flag missing value",
-			args:             []string{testProgramName, "--neo4j-transport-mode"},
-			version:          testVersion,
-			expectedExitCode: 1,
-			expectedStderr:   "--neo4j-transport-mode requires a value",
-		},
-		{
-			name:             "transport mode flag missing value followed by another flag",
-			args:             []string{testProgramName, "--neo4j-transport-mode", "--neo4j-uri", "bolt://localhost:7687"},
-			version:          testVersion,
-			expectedExitCode: 1,
-			expectedStderr:   "--neo4j-transport-mode requires a value (got flag --neo4j-uri instead)",
-		},
-		{
-			name:             "http tls enabled flag with valid value",
-			args:             []string{testProgramName, "--neo4j-http-tls-enabled", "true"},
-			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, flag is allowed
-		},
-		{
-			name:             "http tls enabled flag missing value",
-			args:             []string{testProgramName, "--neo4j-http-tls-enabled"},
-			version:          testVersion,
-			expectedExitCode: 1,
-			expectedStderr:   "--neo4j-http-tls-enabled requires a value",
-		},
-		{
-			name:             "http tls cert file flag with valid value",
-			args:             []string{testProgramName, "--neo4j-http-tls-cert-file", "/path/to/cert.pem"},
-			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, flag is allowed
-		},
-		{
-			name:             "http tls cert file flag missing value",
-			args:             []string{testProgramName, "--neo4j-http-tls-cert-file"},
-			version:          testVersion,
-			expectedExitCode: 1,
-			expectedStderr:   "--neo4j-http-tls-cert-file requires a value",
-		},
-		{
-			name:             "http tls key file flag with valid value",
-			args:             []string{testProgramName, "--neo4j-http-tls-key-file", "/path/to/key.pem"},
-			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, flag is allowed
-		},
-		{
-			name:             "http tls key file flag missing value",
-			args:             []string{testProgramName, "--neo4j-http-tls-key-file"},
-			version:          testVersion,
-			expectedExitCode: 1,
-			expectedStderr:   "--neo4j-http-tls-key-file requires a value",
-		},
-		{
-			name:             "http allowed origins flag with valid value",
-			args:             []string{testProgramName, "--neo4j-http-allowed-origins", "https://example.com"},
-			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, flag is allowed
-		},
-		{
-			name:             "http allowed origins flag with multiple origins",
-			args:             []string{testProgramName, "--neo4j-http-allowed-origins", "https://example.com,https://example2.com"},
-			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, flag is allowed
-		},
-		{
-			name:             "http allowed origins flag missing value",
-			args:             []string{testProgramName, "--neo4j-http-allowed-origins"},
-			version:          testVersion,
-			expectedExitCode: 1,
-			expectedStderr:   "--neo4j-http-allowed-origins requires a value",
-		},
-		{
-			name:             "http auth header name flag with valid value",
-			args:             []string{testProgramName, "--neo4j-http-auth-header-name", "X-Custom-Auth"},
-			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, flag is allowed
-		},
-		{
-			name:             "http auth header name flag missing value",
-			args:             []string{testProgramName, "--neo4j-http-auth-header-name"},
-			version:          testVersion,
-			expectedExitCode: 1,
-			expectedStderr:   "--neo4j-http-auth-header-name requires a value",
-		},
-		{
-			name:             "double dash separator stops flag processing",
-			args:             []string{testProgramName, "--", "--unknown-flag"},
-			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, -- stops our flag processing
-		},
-		{
-			name:             "double dash separator with config flags before it",
-			args:             []string{testProgramName, "--neo4j-uri", "bolt://localhost:7687", "--", "--unknown-flag"},
-			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, config flag before -- is valid
-		},
-		{
-			name:             "http allow unauthenticated ping with valid value",
-			args:             []string{testProgramName, "--neo4j-http-allow-unauthenticated-ping", "true"},
-			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, flag is allowed
-		},
-		{
-			name:             "http allow unauthenticated ping with missing value",
-			args:             []string{testProgramName, "--neo4j-http-allow-unauthenticated-ping"},
-			version:          testVersion,
-			expectedExitCode: 1,
-			expectedStderr:   "--neo4j-http-allow-unauthenticated-ping requires a value",
-		},
-		{
-			name:             "neo4j-tools flag with one tool name",
-			args:             []string{testProgramName, "--neo4j-tools", "get-schema"},
-			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, flag is allowed
-		},
-		{
-			name:             "neo4j-tools flag with trailing comma after tool name",
-			args:             []string{testProgramName, "--neo4j-tools", "get-schema,"},
-			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, flag is allowed
-		},
-		{
-			name:             "neo4j-tools flag with two tool names",
-			args:             []string{testProgramName, "--neo4j-tools", "get-schema,read-cypher"},
-			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, flag is allowed
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			originalArgs := os.Args
-			originalOsExit := osExit
-			t.Cleanup(func() {
-				os.Args = originalArgs
-				osExit = originalOsExit
-			})
-
-			os.Args = tt.args
-			mock := &exitMock{}
-			osExit = mock.Exit
-
-			stdout, stderr := captureOutput(func() {
-				defer func() {
-					if r := recover(); r != mock {
-						if r != nil {
-							panic(r)
-						}
-					}
-				}()
-				HandleArgs(tt.version)
-			})
-
-			shouldExit := tt.expectedExitCode != -1
-			if shouldExit != mock.called {
-				t.Errorf("exit called: got %v, want %v", mock.called, shouldExit)
-			}
-			if mock.called && mock.code != tt.expectedExitCode {
-				t.Errorf("exit code: got %d, want %d", mock.code, tt.expectedExitCode)
-			}
-			if tt.expectedStderr != "" && !strings.Contains(stderr, tt.expectedStderr) {
-				t.Errorf("stderr: got %q, want to contain %q", stderr, tt.expectedStderr)
-			}
-			if tt.expectedOutput != "" && !strings.Contains(stdout, tt.expectedOutput) {
-				t.Errorf("stdout: got %q, want to contain %q", stdout, tt.expectedOutput)
-			}
-		})
-	}
-}
-
-func TestHandleArgs_CanonicalFlags(t *testing.T) {
+func TestHandleArgs(t *testing.T) {
 	tests := []struct {
 		name             string
 		args             []string
@@ -486,35 +240,35 @@ func TestHandleArgs_CanonicalFlags(t *testing.T) {
 			expectedExitCode: -1,
 		},
 		{
-			name:             "neo4j-tools flag with one tool name",
-			args:             []string{testProgramName, "--neo4j-tools", "get-schema"},
+			name:             "tools flag with one tool name",
+			args:             []string{testProgramName, "--tools", "get-schema"},
 			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, flag is allowed
+			expectedExitCode: -1,
 		},
 		{
-			name:             "neo4j-tools flag with trailing comma after tool name",
-			args:             []string{testProgramName, "--neo4j-tools", "get-schema,"},
+			name:             "tools flag with trailing comma after tool name",
+			args:             []string{testProgramName, "--tools", "get-schema,"},
 			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, flag is allowed
+			expectedExitCode: -1,
 		},
 		{
-			name:             "neo4j-tools flag with two tool names",
-			args:             []string{testProgramName, "--neo4j-tools", "get-schema,read-cypher"},
+			name:             "tools flag with two tool names",
+			args:             []string{testProgramName, "--tools", "get-schema,read-cypher"},
 			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, flag is allowed
+			expectedExitCode: -1,
 		},
 		{
-			name:             "neo4j-request-timeout flag with valid value",
-			args:             []string{testProgramName, "--neo4j-request-timeout", "45s"},
+			name:             "request-timeout flag with valid value",
+			args:             []string{testProgramName, "--request-timeout", "45s"},
 			version:          testVersion,
-			expectedExitCode: -1, // Should not exit, flag is allowed
+			expectedExitCode: -1,
 		},
 		{
-			name:             "neo4j-request-timeout flag missing value",
-			args:             []string{testProgramName, "--neo4j-request-timeout"},
+			name:             "request-timeout flag missing value",
+			args:             []string{testProgramName, "--request-timeout"},
 			version:          testVersion,
 			expectedExitCode: 1,
-			expectedStderr:   "--neo4j-request-timeout requires a value",
+			expectedStderr:   "--request-timeout requires a value",
 		},
 	}
 
@@ -556,43 +310,5 @@ func TestHandleArgs_CanonicalFlags(t *testing.T) {
 				t.Errorf("stdout: got %q, want to contain %q", stdout, tt.expectedOutput)
 			}
 		})
-	}
-}
-
-func TestParseConfigFlags_CanonicalFlagPrecedenceAndWarning(t *testing.T) {
-	originalArgs := os.Args
-	originalCommandLine := flag.CommandLine
-	t.Cleanup(func() {
-		os.Args = originalArgs
-		flag.CommandLine = originalCommandLine
-	})
-
-	os.Args = []string{
-		testProgramName,
-		"--uri", "bolt://canonical-host:7687",
-		"--neo4j-uri", "bolt://legacy-host:7687",
-		"--transport-mode", "http",
-		"--neo4j-transport-mode", "stdio",
-	}
-	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
-	flag.CommandLine.SetOutput(io.Discard)
-
-	var args *Args
-	_, stderr := captureOutput(func() {
-		args = ParseConfigFlags()
-	})
-
-	if args.URI != "bolt://canonical-host:7687" {
-		t.Fatalf("ParseConfigFlags() URI = %q, want canonical value", args.URI)
-	}
-	if args.TransportMode != "http" {
-		t.Fatalf("ParseConfigFlags() TransportMode = %q, want canonical value", args.TransportMode)
-	}
-	if !strings.Contains(stderr, `deprecated CLI flag "--neo4j-uri"`) ||
-		!strings.Contains(stderr, `deprecated CLI flag "--neo4j-transport-mode"`) {
-		t.Fatalf("deprecation warnings = %q, want warnings for deprecated flags", stderr)
-	}
-	if strings.Contains(stderr, "legacy-host") {
-		t.Fatalf("deprecation warning exposed configured value: %q", stderr)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,10 +26,9 @@ const (
 	// its write and graceful-shutdown timeouts from this value, so leaving it unbounded
 	// would let a single misconfiguration hold connections open indefinitely. The ceiling
 	// is generous enough for long-running GDS workloads.
-	MaxRequestTimeout         time.Duration = 30 * time.Minute
-	TransportModeStdio        TransportMode = "stdio"
-	TransportModeHTTP         TransportMode = "http"
-	DeprecatedVariableMessage string        = "Warning: deprecated %s %q; use %q instead. Support will be removed in v2.\n"
+	MaxRequestTimeout  time.Duration = 30 * time.Minute
+	TransportModeStdio TransportMode = "stdio"
+	TransportModeHTTP  TransportMode = "http"
 )
 
 // ValidTransportModes defines the allowed transport mode values
@@ -106,7 +105,7 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("Neo4j username and password should not be set for HTTP transport mode; credentials are provided per-request via Auth headers")
 		}
 		if c.Database != "" {
-			return fmt.Errorf("NEO4J_MCP_DATABASE environment variable or ---database flag should not be set for HTTP transport mode; database is selected per-request via URL path (e.g., /db/{databaseName}/mcp)")
+			return fmt.Errorf("NEO4J_MCP_DATABASE environment variable or --database flag should not be set for HTTP transport mode; database is selected per-request via URL path (e.g., /db/{databaseName}/mcp)")
 		}
 	}
 
@@ -168,9 +167,8 @@ type CLIOverrides struct {
 // CLI flag values take precedence over environment variables.
 // Returns an error if required configuration is missing or invalid.
 func LoadConfig(cliOverrides *CLIOverrides) (*Config, error) {
-	warnOnDeprecatedUsage()
-	logLevel := GetEnvWithAliasesDefault("NEO4J_MCP_LOG_LEVEL", "info", "NEO4J_LOG_LEVEL")
-	logFormat := GetEnvWithAliasesDefault("NEO4J_MCP_LOG_FORMAT", "text", "NEO4J_LOG_FORMAT")
+	logLevel := GetEnvWithDefault("NEO4J_MCP_LOG_LEVEL", "info")
+	logFormat := GetEnvWithDefault("NEO4J_MCP_LOG_FORMAT", "text")
 
 	// Validate log level and use default if invalid
 	if !slices.Contains(logger.ValidLogLevels, logLevel) {
@@ -185,25 +183,25 @@ func LoadConfig(cliOverrides *CLIOverrides) (*Config, error) {
 	}
 
 	cfg := &Config{
-		URI:                           GetEnvWithAliases("NEO4J_MCP_URI", "NEO4J_URI"),
-		Username:                      GetEnvWithAliases("NEO4J_MCP_USERNAME", "NEO4J_USERNAME"),
-		Password:                      GetEnvWithAliases("NEO4J_MCP_PASSWORD", "NEO4J_PASSWORD"),
-		Database:                      GetEnvWithAliases("NEO4J_MCP_DATABASE", "NEO4J_DATABASE"),
-		ReadOnly:                      ParseBool(GetEnvWithAliases("NEO4J_MCP_READ_ONLY", "NEO4J_READ_ONLY"), false),
-		Telemetry:                     ParseBool(GetEnvWithAliases("NEO4J_MCP_TELEMETRY", "NEO4J_TELEMETRY"), true),
+		URI:                           GetEnv("NEO4J_MCP_URI"),
+		Username:                      GetEnv("NEO4J_MCP_USERNAME"),
+		Password:                      GetEnv("NEO4J_MCP_PASSWORD"),
+		Database:                      GetEnv("NEO4J_MCP_DATABASE"),
+		ReadOnly:                      ParseBool(GetEnv("NEO4J_MCP_READ_ONLY"), false),
+		Telemetry:                     ParseBool(GetEnv("NEO4J_MCP_TELEMETRY"), true),
 		LogLevel:                      logLevel,
 		LogFormat:                     logFormat,
-		SchemaSampleSize:              ParseInt32(GetEnvWithAliases("NEO4J_MCP_SCHEMA_SAMPLE_SIZE", "NEO4J_SCHEMA_SAMPLE_SIZE"), DefaultSchemaSampleSize),
-		TransportMode:                 TransportMode(GetEnvWithAliasesDefault("NEO4J_MCP_TRANSPORT_MODE", string(TransportModeStdio), "NEO4J_TRANSPORT_MODE", "NEO4J_MCP_TRANSPORT")),
+		SchemaSampleSize:              ParseInt32(GetEnv("NEO4J_MCP_SCHEMA_SAMPLE_SIZE"), DefaultSchemaSampleSize),
+		TransportMode:                 GetTransportModeWithDefault("NEO4J_MCP_TRANSPORT_MODE", TransportModeStdio),
 		HTTPPort:                      GetEnv("NEO4J_MCP_HTTP_PORT"), // Default set after TLS determination
 		HTTPHost:                      GetEnvWithDefault("NEO4J_MCP_HTTP_HOST", "127.0.0.1"),
 		HTTPAllowedOrigins:            GetEnv("NEO4J_MCP_HTTP_ALLOWED_ORIGINS"),
 		HTTPTLSEnabled:                ParseBool(GetEnv("NEO4J_MCP_HTTP_TLS_ENABLED"), false),
 		HTTPTLSCertFile:               GetEnv("NEO4J_MCP_HTTP_TLS_CERT_FILE"),
 		HTTPTLSKeyFile:                GetEnv("NEO4J_MCP_HTTP_TLS_KEY_FILE"),
-		AuthHeaderName:                GetEnvWithAliasesDefault("NEO4J_MCP_HTTP_AUTH_HEADER_NAME", "Authorization", "NEO4J_HTTP_AUTH_HEADER_NAME"),
-		AllowUnauthenticatedPing:      ParseBool(GetEnvWithAliases("NEO4J_MCP_HTTP_ALLOW_UNAUTHENTICATED_PING", "NEO4J_HTTP_ALLOW_UNAUTHENTICATED_PING"), false),
-		AllowUnauthenticatedToolsList: ParseBool(GetEnvWithAliases("NEO4J_MCP_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST", "NEO4J_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST"), false),
+		AuthHeaderName:                GetEnvWithDefault("NEO4J_MCP_HTTP_AUTH_HEADER_NAME", "Authorization"),
+		AllowUnauthenticatedPing:      ParseBool(GetEnv("NEO4J_MCP_HTTP_ALLOW_UNAUTHENTICATED_PING"), false),
+		AllowUnauthenticatedToolsList: ParseBool(GetEnv("NEO4J_MCP_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST"), false),
 	}
 
 	requestTimeout, err := ParseDuration(GetEnv("NEO4J_MCP_REQUEST_TIMEOUT"), DefaultRequestTimeout)
@@ -275,7 +273,7 @@ func LoadConfig(cliOverrides *CLIOverrides) (*Config, error) {
 		if cliOverrides.RequestTimeout != "" {
 			requestTimeout, err := ParseDuration(cliOverrides.RequestTimeout, DefaultRequestTimeout)
 			if err != nil {
-				return nil, fmt.Errorf("invalid --neo4j-request-timeout: %w", err)
+				return nil, fmt.Errorf("invalid --request-timeout: %w", err)
 			}
 			cfg.RequestTimeout = requestTimeout
 		}
@@ -316,57 +314,6 @@ func LoadConfig(cliOverrides *CLIOverrides) (*Config, error) {
 // GetEnv returns the value of an environment variable or empty string if not set
 func GetEnv(key string) string {
 	return os.Getenv(key)
-}
-
-// GetEnvWithAliases returns the canonical environment variable value, falling
-// back to deprecated aliases when the canonical variable is unset or empty.
-func GetEnvWithAliases(canonical string, aliases ...string) string {
-	if value := os.Getenv(canonical); value != "" {
-		return value
-	}
-	for _, alias := range aliases {
-		if value := os.Getenv(alias); value != "" {
-			return value
-		}
-	}
-	return ""
-}
-
-var deprecatedEnvironmentVariables = []struct {
-	alias     string
-	canonical string
-}{
-	{alias: "NEO4J_URI", canonical: "NEO4J_MCP_URI"},
-	{alias: "NEO4J_USERNAME", canonical: "NEO4J_MCP_USERNAME"},
-	{alias: "NEO4J_PASSWORD", canonical: "NEO4J_MCP_PASSWORD"},
-	{alias: "NEO4J_DATABASE", canonical: "NEO4J_MCP_DATABASE"},
-	{alias: "NEO4J_READ_ONLY", canonical: "NEO4J_MCP_READ_ONLY"},
-	{alias: "NEO4J_TELEMETRY", canonical: "NEO4J_MCP_TELEMETRY"},
-	{alias: "NEO4J_LOG_LEVEL", canonical: "NEO4J_MCP_LOG_LEVEL"},
-	{alias: "NEO4J_LOG_FORMAT", canonical: "NEO4J_MCP_LOG_FORMAT"},
-	{alias: "NEO4J_TRANSPORT_MODE", canonical: "NEO4J_MCP_TRANSPORT_MODE"},
-	{alias: "NEO4J_MCP_TRANSPORT", canonical: "NEO4J_MCP_TRANSPORT_MODE"},
-	{alias: "NEO4J_SCHEMA_SAMPLE_SIZE", canonical: "NEO4J_MCP_SCHEMA_SAMPLE_SIZE"},
-	{alias: "NEO4J_HTTP_AUTH_HEADER_NAME", canonical: "NEO4J_MCP_HTTP_AUTH_HEADER_NAME"},
-	{alias: "NEO4J_HTTP_ALLOW_UNAUTHENTICATED_PING", canonical: "NEO4J_MCP_HTTP_ALLOW_UNAUTHENTICATED_PING"},
-	{alias: "NEO4J_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST", canonical: "NEO4J_MCP_HTTP_ALLOW_UNAUTHENTICATED_TOOLS_LIST"},
-}
-
-func warnOnDeprecatedUsage() {
-	for _, variable := range deprecatedEnvironmentVariables {
-		if os.Getenv(variable.alias) != "" {
-			fmt.Fprintf(os.Stderr, DeprecatedVariableMessage, "environment variable", variable.alias, variable.canonical)
-		}
-	}
-}
-
-// GetEnvWithAliasesDefault returns the canonical or deprecated environment
-// variable value, or defaultValue when all names are unset or empty.
-func GetEnvWithAliasesDefault(canonical, defaultValue string, aliases ...string) string {
-	if value := GetEnvWithAliases(canonical, aliases...); value != "" {
-		return value
-	}
-	return defaultValue
 }
 
 // GetEnvWithDefault returns the value of an environment variable or a default value

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -107,7 +107,7 @@ func TestConfig_Validate(t *testing.T) {
 				TransportMode: TransportModeHTTP,
 			},
 			wantErr: true,
-			errMsg:  "NEO4J_MCP_DATABASE environment variable or ---database flag should not be set for HTTP transport mode; database is selected per-request via URL path (e.g., /db/{databaseName}/mcp)",
+			errMsg:  "NEO4J_MCP_DATABASE environment variable or --database flag should not be set for HTTP transport mode; database is selected per-request via URL path (e.g., /db/{databaseName}/mcp)",
 		},
 		{
 			name: "credentials set for HTTP mode should raise error",
@@ -168,53 +168,6 @@ func TestLoadConfig_ValidConfig(t *testing.T) {
 	cfg, err := LoadConfig(nil)
 	if err != nil {
 		t.Fatalf("LoadConfig() unexpected error: %v", err)
-	}
-
-	if cfg == nil {
-		t.Fatal("LoadConfig() returned nil config")
-	}
-
-	if cfg.URI != "bolt://localhost:7687" {
-		t.Errorf("LoadConfig() URI = %v, want bolt://localhost:7687", cfg.URI)
-	}
-	if cfg.Username != "testuser" {
-		t.Errorf("LoadConfig() Username = %v, want testuser", cfg.Username)
-	}
-	if cfg.Password != "testpass" {
-		t.Errorf("LoadConfig() Password = %v, want testpass", cfg.Password)
-	}
-	if cfg.Database != "neo4j" {
-		t.Errorf("LoadConfig() Database = %v, want neo4j", cfg.Database)
-	}
-}
-
-func TestLoadConfig_DeprecatedValidConfig(t *testing.T) {
-	// Unit test: set required env variables and verify LoadConfig works
-	t.Setenv("NEO4J_MCP_TRANSPORT", "stdio")
-	t.Setenv("NEO4J_URI", "bolt://localhost:7687")
-	t.Setenv("NEO4J_USERNAME", "testuser")
-	t.Setenv("NEO4J_PASSWORD", "testpass")
-	t.Setenv("NEO4J_DATABASE", "neo4j")
-
-	var cfg *Config
-	var loadErr error
-	_, stderr := captureOutput(func() {
-		cfg, loadErr = LoadConfig(nil)
-	})
-	if loadErr != nil {
-		t.Fatalf("LoadConfig() unexpected error: %v", loadErr)
-	}
-
-	for _, alias := range []string{
-		"NEO4J_MCP_TRANSPORT",
-		"NEO4J_URI",
-		"NEO4J_USERNAME",
-		"NEO4J_PASSWORD",
-		"NEO4J_DATABASE",
-	} {
-		if !strings.Contains(stderr, `deprecated environment variable "`+alias+`"`) {
-			t.Errorf("deprecation warnings = %q, want warning for %s", stderr, alias)
-		}
 	}
 
 	if cfg == nil {
@@ -308,8 +261,6 @@ func TestLoadConfig_PartialCLIOverrides(t *testing.T) {
 	overrides := &CLIOverrides{
 		URI:      "bolt://cli-host:7687",
 		Username: "cli-user",
-		Password: "",
-		Database: "",
 	}
 
 	cfg, err := LoadConfig(overrides)
@@ -479,7 +430,7 @@ func TestLoadConfig_CanonicalEnvironmentVariables(t *testing.T) {
 		t.Fatalf("LoadConfig() unexpected error: %v", loadErr)
 	}
 	if stderr != "" {
-		t.Fatalf("LoadConfig() emitted unexpected deprecation warning: %q", stderr)
+		t.Fatalf("LoadConfig() emitted unexpected warning: %q", stderr)
 	}
 
 	if cfg.URI != "bolt://canonical-host:7687" ||
@@ -525,62 +476,6 @@ func TestLoadConfig_InvalidLogConfigurationFallsBackToDefaults(t *testing.T) {
 	}
 	if !strings.Contains(stderr, "invalid NEO4J_MCP_LOG_FORMAT 'JSON'") {
 		t.Errorf("stderr = %q, want invalid log format warning", stderr)
-	}
-}
-
-func TestLoadConfig_DeprecatedEnvironmentAliasWarningAndPrecedence(t *testing.T) {
-	t.Setenv("NEO4J_MCP_URI", "bolt://canonical-host:7687")
-	t.Setenv("NEO4J_MCP_USERNAME", "canonical-user")
-	t.Setenv("NEO4J_MCP_PASSWORD", "canonical-password")
-	t.Setenv("NEO4J_MCP_DATABASE", "canonical-db")
-	t.Setenv("NEO4J_MCP_TRANSPORT_MODE", "stdio")
-	t.Setenv("NEO4J_URI", "bolt://legacy-host:7687")
-
-	var cfg *Config
-	var loadErr error
-	_, stderr := captureOutput(func() {
-		cfg, loadErr = LoadConfig(nil)
-	})
-	if loadErr != nil {
-		t.Fatalf("LoadConfig() unexpected error: %v", loadErr)
-	}
-	if cfg.URI != "bolt://canonical-host:7687" {
-		t.Fatalf("LoadConfig() URI = %q, want canonical value", cfg.URI)
-	}
-	if !strings.Contains(stderr, `deprecated environment variable "NEO4J_URI"`) {
-		t.Fatalf("deprecation warning = %q, want NEO4J_URI warning", stderr)
-	}
-	if !strings.Contains(stderr, "NEO4J_MCP_URI") {
-		t.Fatalf("deprecation warning = %q, want canonical replacement", stderr)
-	}
-	if strings.Contains(stderr, "legacy-host") {
-		t.Fatalf("deprecation warning exposed configured value: %q", stderr)
-	}
-}
-
-func TestLoadConfig_TransportEnvironmentAliasPrecedence(t *testing.T) {
-	t.Setenv("NEO4J_MCP_URI", "bolt://canonical-host:7687")
-	t.Setenv("NEO4J_MCP_USERNAME", "canonical-user")
-	t.Setenv("NEO4J_MCP_PASSWORD", "canonical-password")
-	t.Setenv("NEO4J_MCP_DATABASE", "canonical-db")
-	t.Setenv("NEO4J_MCP_TRANSPORT_MODE", "")
-	t.Setenv("NEO4J_TRANSPORT_MODE", "stdio")
-	t.Setenv("NEO4J_MCP_TRANSPORT", "http")
-
-	var cfg *Config
-	var loadErr error
-	_, stderr := captureOutput(func() {
-		cfg, loadErr = LoadConfig(nil)
-	})
-	if loadErr != nil {
-		t.Fatalf("LoadConfig() unexpected error: %v", loadErr)
-	}
-	if cfg.TransportMode != TransportModeStdio {
-		t.Fatalf("LoadConfig() TransportMode = %q, want NEO4J_TRANSPORT_MODE precedence", cfg.TransportMode)
-	}
-	if !strings.Contains(stderr, `deprecated environment variable "NEO4J_TRANSPORT_MODE"`) ||
-		!strings.Contains(stderr, `deprecated environment variable "NEO4J_MCP_TRANSPORT"`) {
-		t.Fatalf("deprecation warnings = %q, want both transport aliases", stderr)
 	}
 }
 
@@ -727,9 +622,7 @@ func TestLoadConfig_TLS(t *testing.T) {
 		t.Setenv("NEO4J_MCP_HTTP_TLS_CERT_FILE", certPath)
 		t.Setenv("NEO4J_MCP_HTTP_TLS_KEY_FILE", keyPath)
 
-		overrides := &CLIOverrides{
-			TLSEnabled: "true",
-		}
+		overrides := &CLIOverrides{TLSEnabled: "true"}
 
 		cfg, err := LoadConfig(overrides)
 		if err != nil {
@@ -847,9 +740,7 @@ func TestLoadConfig_DefaultHTTPPort(t *testing.T) {
 		t.Setenv("NEO4J_MCP_HTTP_TLS_KEY_FILE", keyPath)
 		// Don't set NEO4J_MCP_HTTP_PORT in environment
 
-		overrides := &CLIOverrides{
-			Port: "9443",
-		}
+		overrides := &CLIOverrides{Port: "9443"}
 
 		cfg, err := LoadConfig(overrides)
 		if err != nil {
@@ -870,9 +761,7 @@ func TestLoadConfig_DefaultHTTPPort(t *testing.T) {
 		t.Setenv("NEO4J_MCP_HTTP_TLS_KEY_FILE", keyPath)
 		// Don't set NEO4J_MCP_HTTP_PORT
 
-		overrides := &CLIOverrides{
-			TLSEnabled: "true",
-		}
+		overrides := &CLIOverrides{TLSEnabled: "true"}
 
 		cfg, err := LoadConfig(overrides)
 		if err != nil {
@@ -928,7 +817,7 @@ func TestLoadConfig_HTTPAllowedOrigins(t *testing.T) {
 		t.Setenv("NEO4J_MCP_USERNAME", "neo4j")
 		t.Setenv("NEO4J_MCP_PASSWORD", "password")
 		t.Setenv("NEO4J_MCP_DATABASE", "neo4j")
-		t.Setenv("NEO4J_DATABASE", "neo4j")
+		t.Setenv("NEO4J_MCP_DATABASE", "neo4j")
 		// Don't set NEO4J_MCP_HTTP_ALLOWED_ORIGINS
 
 		cfg, err := LoadConfig(nil)
@@ -946,12 +835,10 @@ func TestLoadConfig_HTTPAllowedOrigins(t *testing.T) {
 		t.Setenv("NEO4J_MCP_URI", "bolt://localhost:7687")
 		t.Setenv("NEO4J_MCP_USERNAME", "neo4j")
 		t.Setenv("NEO4J_MCP_PASSWORD", "password")
-		t.Setenv("NEO4J_DATABASE", "neo4j")
+		t.Setenv("NEO4J_MCP_DATABASE", "neo4j")
 		t.Setenv("NEO4J_MCP_HTTP_ALLOWED_ORIGINS", "https://env-example.com")
 
-		overrides := &CLIOverrides{
-			AllowedOrigins: "https://cli-example.com",
-		}
+		overrides := &CLIOverrides{AllowedOrigins: "https://cli-example.com"}
 
 		cfg, err := LoadConfig(overrides)
 		if err != nil {
@@ -1011,9 +898,7 @@ func TestLoadConfig_AuthHeaderName(t *testing.T) {
 		t.Setenv("NEO4J_MCP_HTTP_AUTH_HEADER_NAME", "X-Env-Auth")
 		t.Setenv("NEO4J_MCP_DATABASE", "neo4j")
 
-		overrides := &CLIOverrides{
-			AuthHeaderName: "X-CLI-Auth",
-		}
+		overrides := &CLIOverrides{AuthHeaderName: "X-CLI-Auth"}
 
 		cfg, err := LoadConfig(overrides)
 		if err != nil {
@@ -1033,9 +918,7 @@ func TestLoadConfig_AuthHeaderName(t *testing.T) {
 		t.Setenv("NEO4J_MCP_PASSWORD", "password")
 		t.Setenv("NEO4J_MCP_DATABASE", "neo4j")
 
-		overrides := &CLIOverrides{
-			AuthHeaderName: "   ", // non-empty but only whitespace -> should be trimmed to empty and cause an error
-		}
+		overrides := &CLIOverrides{AuthHeaderName: "   "} // non-empty but only whitespace -> should be trimmed to empty and cause an error
 
 		cfg, err := LoadConfig(overrides)
 		if err == nil {
@@ -1151,16 +1034,16 @@ func TestLoadConfig_Neo4jMCPToolsEnvVar(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("NEO4J_TRANSPORT_MODE", "stdio")
-			t.Setenv("NEO4J_URI", "bolt://localhost:7687")
-			t.Setenv("NEO4J_USERNAME", "neo4j")
-			t.Setenv("NEO4J_PASSWORD", "password")
-			t.Setenv("NEO4J_DATABASE", "neo4j")
+			t.Setenv("NEO4J_MCP_TRANSPORT_MODE", "stdio")
+			t.Setenv("NEO4J_MCP_URI", "bolt://localhost:7687")
+			t.Setenv("NEO4J_MCP_USERNAME", "neo4j")
+			t.Setenv("NEO4J_MCP_PASSWORD", "password")
+			t.Setenv("NEO4J_MCP_DATABASE", "neo4j")
 			if tt.toolsEnv != nil {
 				t.Setenv("NEO4J_MCP_TOOLS", *tt.toolsEnv)
 			}
 
-			cfg, err := LoadConfig(&CLIOverrides{})
+			cfg, err := LoadConfig(nil)
 
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
@@ -1225,18 +1108,20 @@ func TestLoadConfig_Neo4jMCPToolsCLIOverride(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("NEO4J_TRANSPORT_MODE", "stdio")
-			t.Setenv("NEO4J_URI", "bolt://localhost:7687")
-			t.Setenv("NEO4J_USERNAME", "neo4j")
-			t.Setenv("NEO4J_PASSWORD", "password")
-			t.Setenv("NEO4J_DATABASE", "neo4j")
+			t.Setenv("NEO4J_MCP_TRANSPORT_MODE", "stdio")
+			t.Setenv("NEO4J_MCP_URI", "bolt://localhost:7687")
+			t.Setenv("NEO4J_MCP_USERNAME", "neo4j")
+			t.Setenv("NEO4J_MCP_PASSWORD", "password")
+			t.Setenv("NEO4J_MCP_DATABASE", "neo4j")
 			if tt.toolsEnv != "" {
 				t.Setenv("NEO4J_MCP_TOOLS", tt.toolsEnv)
 			}
 
-			cfg, err := LoadConfig(&CLIOverrides{
-				Tools: tt.cliTools,
-			})
+			overrides := &CLIOverrides{}
+			if tt.cliTools != nil {
+				overrides.Tools = tt.cliTools
+			}
+			cfg, err := LoadConfig(overrides)
 
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
@@ -1254,11 +1139,11 @@ func newStringPtr(s string) *string {
 }
 
 func TestLoadConfig_RequestTimeout(t *testing.T) {
-	t.Setenv("NEO4J_TRANSPORT_MODE", "stdio")
-	t.Setenv("NEO4J_URI", "bolt://localhost:7687")
-	t.Setenv("NEO4J_USERNAME", "testuser")
-	t.Setenv("NEO4J_PASSWORD", "testpass")
-	t.Setenv("NEO4J_DATABASE", "neo4j")
+	t.Setenv("NEO4J_MCP_TRANSPORT_MODE", "stdio")
+	t.Setenv("NEO4J_MCP_URI", "bolt://localhost:7687")
+	t.Setenv("NEO4J_MCP_USERNAME", "testuser")
+	t.Setenv("NEO4J_MCP_PASSWORD", "testpass")
+	t.Setenv("NEO4J_MCP_DATABASE", "neo4j")
 
 	t.Run("default value", func(t *testing.T) {
 		t.Setenv("NEO4J_MCP_REQUEST_TIMEOUT", "")
@@ -1293,7 +1178,8 @@ func TestLoadConfig_RequestTimeout(t *testing.T) {
 	t.Run("cli override", func(t *testing.T) {
 		t.Setenv("NEO4J_MCP_REQUEST_TIMEOUT", "45s")
 
-		cfg, err := LoadConfig(&CLIOverrides{RequestTimeout: "20s"})
+		overrides := &CLIOverrides{RequestTimeout: "20s"}
+		cfg, err := LoadConfig(overrides)
 		require.NoError(t, err)
 		assert.Equal(t, 20*time.Second, cfg.RequestTimeout)
 	})
@@ -1316,7 +1202,8 @@ func TestLoadConfig_RequestTimeout(t *testing.T) {
 	t.Run("above the maximum is rejected from the CLI flag", func(t *testing.T) {
 		t.Setenv("NEO4J_MCP_REQUEST_TIMEOUT", "")
 
-		_, err := LoadConfig(&CLIOverrides{RequestTimeout: "100h"})
+		overrides := &CLIOverrides{RequestTimeout: "100h"}
+		_, err := LoadConfig(overrides)
 		require.ErrorContains(t, err, "must not exceed 30m0s")
 	})
 }

--- a/internal/server/tools_register.go
+++ b/internal/server/tools_register.go
@@ -18,7 +18,7 @@ import (
 // Tools are filtered according to the server configuration. For example, when the read-only
 // mode is enabled (e.g. via the Config.ReadOnly flag, which can be set by the NEO4J_MCP_READ_ONLY environment variable or --read-only flag),
 // any tool that performs state mutation will be excluded.
-// Individual tools can also be selected via Config.Tools, which can be set by the NEO4J_MCP_TOOLS environment variable or -tools flag, with Config.ReadOnly taking precedence.
+// Individual tools can also be selected via Config.Tools, which can be set by the NEO4J_MCP_TOOLS environment variable or --tools flag, with Config.ReadOnly taking precedence.
 func (s *Neo4jMCPServer) registerTools() {
 	tools := s.getTools()
 	s.MCPServer.AddTools(tools...)

--- a/test/containerrunner/container_runner.go
+++ b/test/containerrunner/container_runner.go
@@ -83,7 +83,6 @@ func startOnce(ctx context.Context) {
 		Close(ctx)
 		log.Fatalf("failed to verify connectivity: %v", err)
 	}
-
 }
 
 // Close cleans up shared resources used in integration tests

--- a/test/e2e/http_server_helpers_test.go
+++ b/test/e2e/http_server_helpers_test.go
@@ -28,7 +28,7 @@ import (
 // startHTTPModeServer launches the server binary in HTTP mode on a random free port.
 // It polls /healthz until the server is ready and returns the base URL.
 // The server process is automatically terminated when the test ends.
-// extraArgs are appended to the server command line (e.g. "--neo4j-request-timeout", "5s").
+// extraArgs are appended to the server command line (e.g. "--request-timeout", "5s").
 func startHTTPModeServer(t *testing.T, extraArgs ...string) string {
 	t.Helper()
 
@@ -42,10 +42,10 @@ func startHTTPModeServer(t *testing.T, extraArgs ...string) string {
 	// X-Neo4j-MCP-URI header, Auth headers, and URL path respectively.
 	// Strip those keys so any locally-set env values don't cause a startup validation error.
 	args := append([]string{
-		"--neo4j-transport-mode", "http",
-		"--neo4j-http-host", "127.0.0.1",
-		"--neo4j-http-port", fmt.Sprintf("%d", port),
-		"--neo4j-telemetry", "false",
+		"--transport-mode", "http",
+		"--http-host", "127.0.0.1",
+		"--http-port", fmt.Sprintf("%d", port),
+		"--telemetry", "false",
 	}, extraArgs...)
 	cmd := exec.Command(server, args...) // #nosec G204 -- server is a binary path built by the test harness, not user input
 	cmd.Env = stripEnv(os.Environ(), "NEO4J_URI", "NEO4J_USERNAME", "NEO4J_PASSWORD", "NEO4J_DATABASE", "NEO4J_MCP_URI", "NEO4J_MCP_USERNAME", "NEO4J_MCP_PASSWORD", "NEO4J_MCP_DATABASE")

--- a/test/e2e/http_server_request_timeout_test.go
+++ b/test/e2e/http_server_request_timeout_test.go
@@ -23,7 +23,7 @@ import (
 func TestHTTPRequestTimeoutHeaderValidation(t *testing.T) {
 	t.Parallel()
 
-	baseURL := startHTTPModeServer(t, "--neo4j-request-timeout", "5s")
+	baseURL := startHTTPModeServer(t, "--request-timeout", "5s")
 
 	tests := []struct {
 		name     string
@@ -95,7 +95,7 @@ func TestHTTPRequestTimeoutInitialize(t *testing.T) {
 		},
 		{
 			name:       "When the server maximum timeout expires, initialize should fail with the timeout error",
-			serverArgs: []string{"--neo4j-request-timeout", "1ms"},
+			serverArgs: []string{"--request-timeout", "1ms"},
 			wantErr:    "request timed out after 1ms",
 		},
 	}

--- a/test/e2e/http_server_request_timeout_test.go
+++ b/test/e2e/http_server_request_timeout_test.go
@@ -146,10 +146,10 @@ func TestHTTPRequestTimeoutToolCall(t *testing.T) {
 	}{
 		{
 			name:      "When the tool call exceeds the request timeout, a timeout tool error should be returned",
-			timeout:   "2s",
-			query:     "CALL apoc.util.sleep(5000) RETURN 1 AS n",
+			timeout:   "5s",
+			query:     "CALL apoc.util.sleep(6000) RETURN 1 AS n",
 			wantError: true,
-			wantMsg:   "request timed out after 2s",
+			wantMsg:   "request timed out after 5s",
 		},
 		{
 			name:      "When the tool call completes within the request timeout, it should succeed",

--- a/test/e2e/stdio_server_request_timeout_test.go
+++ b/test/e2e/stdio_server_request_timeout_test.go
@@ -19,7 +19,7 @@ import (
 
 // TestStdioRequestTimeoutInitialize verifies that an expired server request
 // timeout is surfaced as a clear error during initialize. STDIO has no per-request
-// timeout header, so only the server maximum (--neo4j-request-timeout) applies.
+// timeout header, so only the server maximum (--request-timeout) applies.
 func TestStdioRequestTimeoutInitialize(t *testing.T) {
 	t.Parallel()
 
@@ -42,12 +42,12 @@ func TestStdioRequestTimeoutInitialize(t *testing.T) {
 			cfg := dbs.GetDriverConf()
 
 			args := []string{
-				"--neo4j-uri", cfg.URI,
-				"--neo4j-username", cfg.Username,
-				"--neo4j-password", cfg.Password,
-				"--neo4j-database", cfg.Database,
-				"--neo4j-telemetry", "false",
-				"--neo4j-request-timeout", tc.timeout,
+				"--uri", cfg.URI,
+				"--username", cfg.Username,
+				"--password", cfg.Password,
+				"--database", cfg.Database,
+				"--telemetry", "false",
+				"--request-timeout", tc.timeout,
 			}
 
 			mcpClient, err := client.NewStdioMCPClient(server, []string{}, args...)
@@ -98,12 +98,12 @@ func TestStdioRequestTimeoutToolCall(t *testing.T) {
 			cfg := dbs.GetDriverConf()
 
 			args := []string{
-				"--neo4j-uri", cfg.URI,
-				"--neo4j-username", cfg.Username,
-				"--neo4j-password", cfg.Password,
-				"--neo4j-database", cfg.Database,
-				"--neo4j-telemetry", "false",
-				"--neo4j-request-timeout", tc.timeout,
+				"--uri", cfg.URI,
+				"--username", cfg.Username,
+				"--password", cfg.Password,
+				"--database", cfg.Database,
+				"--telemetry", "false",
+				"--request-timeout", tc.timeout,
 			}
 
 			mcpClient, err := client.NewStdioMCPClient(server, []string{}, args...)


### PR DESCRIPTION
As for title, this PR removes the deprecated environment variables in favour of the scoped `NEO4J_MCP_*` one. It also removes the CLI args prefixes `--neo4j-*`. 
In this PR is also found the migration in place for environment variables and CLI args introduced in the 2.x and not yet released such as `--request-timeout` and `--tools`.