### PR TITLE
pin gorelease version as latest version contains a bug which prevent release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
-          version: latest
+          # Pinned to v2.18.0: v2.18.1 breaks tag parsing (goreleaser/goreleaser#7122).
+          # TODO: revert to "latest" once a stable release with the fix (v2.19.0+) is out.
+          version: v2.18.0
           args: --clean --release-notes=${{ env.RELEASE_NOTES_PATH }} --skip=validate --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.TEAM_GRAPHQL_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
Temporary pin the gorelease version used in the `release.yml` workflow which prevent to the project to be released 
https://github.com/goreleaser/goreleaser/issues/7122 the fix has been merged but is only present in a pre-release version which is not used when using the "latest" identifier by goreleaser/goreleaser-action